### PR TITLE
📌 configure pinning GitHub action digests

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:recommended", ":gitSignOff"],
+  extends: ["config:recommended", ":gitSignOff", "helpers:pinGitHubActionDigests"],
   prHourlyLimit: 10,
   enabledManagers: ["github-actions", "pre-commit"],
   "pre-commit": {


### PR DESCRIPTION
This configures renovate to pin GitHub Actions to explicit digests in an effort to improve security given some recent precedents across the ecosystem.