### PR TITLE
🔧 use `pull_request` event trigger for release drafter and no more auto labeled

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -49,10 +49,6 @@ version-resolver:
     labels:
       - "patch"
   default: patch
-autolabeler:
-  - label: "dependencies"
-    title:
-      - "/update pre-commit hooks/i"
 
 template: |
   ## 👀 What Changed

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,7 +12,7 @@ on:
   push:
     branches:
       - main
-  pull_request_target:
+  pull_request:
     types: [opened, reopened, synchronize]
 
 permissions:


### PR DESCRIPTION
Simplifies the release drafter configuration to no longer relying on the auto labeler.
As a result the `pull_request_target` trigger is no longer necessary for the workflow to succeed on PRs from forks.