### PR TITLE
👷 Add Windows 11 ARM runners

### DIFF
--- a/.github/workflows/reusable-cpp-ci.yml
+++ b/.github/workflows/reusable-cpp-ci.yml
@@ -168,7 +168,7 @@ on:
         default: ""
         type: string
       ###---- Windows-specific inputs -------------------------------------------------------------------------------###
-      ### Runs (windows-2022, windows-2025) x (msvc, clang) x (Release, Debug)
+      ### Runs (windows-2022, windows-2025, windows-11-arm) x (msvc, clang) x (Release, Debug)
       ### Defaults are
       ### - windows-2022, msvc, Release,
       ###------------------------------------------------------------------------------------------------------------###
@@ -206,6 +206,22 @@ on:
         type: boolean
       enable-windows2025-clang-debug:
         description: "Whether to enable C++ testing on Windows 2025 with Clang in Debug mode"
+        default: false
+        type: boolean
+      enable-windows11-arm-msvc-release:
+        description: "Whether to enable C++ testing on Windows 11 ARM with MSVC in Release mode"
+        default: false
+        type: boolean
+      enable-windows11-arm-msvc-debug:
+        description: "Whether to enable C++ testing on Windows 11 ARM with MSVC in Debug mode"
+        default: false
+        type: boolean
+      enable-windows11-arm-clang-release:
+        description: "Whether to enable C++ testing on Windows 11 ARM with Clang in Release mode"
+        default: false
+        type: boolean
+      enable-windows11-arm-clang-debug:
+        description: "Whether to enable C++ testing on Windows 11 ARM with Clang in Debug mode"
         default: false
         type: boolean
       cmake-args-windows:
@@ -344,6 +360,18 @@ jobs:
           fi
           if [ "${{ inputs.enable-windows2025-clang-debug }}" == "true" ]; then
             windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-2025", "config": "Debug", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-windows11-arm-msvc-release }}" == "true" ]; then
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-11-arm", "config": "Release", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows11-arm-msvc-debug }}" == "true" ]; then
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-11-arm", "config": "Debug", "compiler": "msvc"}]')
+          fi
+          if [ "${{ inputs.enable-windows11-arm-clang-release }}" == "true" ]; then
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-11-arm", "config": "Release", "compiler": "clang"}]')
+          fi
+          if [ "${{ inputs.enable-windows11-arm-clang-debug }}" == "true" ]; then
+            windows_matrix=$(echo $windows_matrix | jq '. += [{"runs-on": "windows-11-arm", "config": "Debug", "compiler": "clang"}]')
           fi
           echo "windows-matrix=$(echo $windows_matrix | jq -rc .)" >> $GITHUB_OUTPUT
           echo $(echo $windows_matrix | jq -rc .)

--- a/.github/workflows/reusable-python-ci.yml
+++ b/.github/workflows/reusable-python-ci.yml
@@ -61,7 +61,7 @@ on:
         default: false
         type: boolean
       ###---- Windows-specific inputs -------------------------------------------------------------------------------###
-      ### Runs (windows-2022, windows-2025)
+      ### Runs (windows-2022, windows-2025, windows-11-arm)
       ### Defaults are
       ### - windows-2022
       ###------------------------------------------------------------------------------------------------------------###
@@ -71,6 +71,10 @@ on:
         type: boolean
       enable-windows2025:
         description: "Whether to enable the Windows 2025 runner"
+        default: false
+        type: boolean
+      enable-windows11-arm:
+        description: "Whether to enable the Windows 11 ARM runner"
         default: false
         type: boolean
 
@@ -110,6 +114,9 @@ jobs:
           fi
           if [ "${{ inputs.enable-windows2025 }}" = "true" ]; then
             matrix=$(echo $matrix | jq '. + [{"runs-on": "windows-2025"}]')
+          fi
+          if [ "${{ inputs.enable-windows11-arm }}" = "true" ]; then
+            matrix=$(echo $matrix | jq '. + [{"runs-on": "windows-11-arm"}]')
           fi
           echo "matrix=$(echo $matrix | jq -rc .)" >> $GITHUB_OUTPUT
           echo $(echo $matrix | jq -rc .)

--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -83,7 +83,14 @@ jobs:
       matrix:
         # build wheels for all supported Python versions on all platforms
         runs-on:
-          [ubuntu-24.04, ubuntu-24.04-arm, macos-13, macos-14, windows-latest]
+          [
+            ubuntu-24.04,
+            ubuntu-24.04-arm,
+            macos-13,
+            macos-14,
+            windows-latest,
+            windows-11-arm,
+          ]
     steps:
       # check out the repository (including submodules and all history)
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Just yesterday, GitHub [announced](https://github.blog/changelog/2025-04-14-windows-arm64-hosted-runners-now-available-in-public-preview/) the general availability of Windows ARM runners in public preview.
This PR adds the respective runners to the C++ tests, the Python tests, as well as the Python packaging workflow.
The test workflows are currently opt-in only and will not be run by default.
The packaging workflow now includes the Windows ARM runners.
This configuration will be updated in a subsequent PR to allow opting in and out of runners for CD.