### PR TITLE
🔥 remove `msvc-dev-cmd`

### DIFF
--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -63,8 +63,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      # set up MSVC development environment
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       # optionally set up Z3
       - if: ${{ inputs.setup-z3 }}
         name: Setup Z3

--- a/.github/workflows/reusable-python-packaging.yml
+++ b/.github/workflows/reusable-python-packaging.yml
@@ -190,8 +190,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      # set up MSVC development environment (Windows only)
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       # optionally set up Z3 (non-Ubuntu only)
       - if: ${{ inputs.setup-z3 && matrix.runs-on != 'ubuntu-24.04' && matrix.runs-on != 'ubuntu-24.04-arm' && matrix.runs-on != 'ubuntu-22.04' && matrix.runs-on != 'ubuntu-22.04-arm' }}
         name: Setup Z3

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -36,8 +36,6 @@ jobs:
         with:
           submodules: recursive
           fetch-depth: 0
-      # set up MSVC development environment (Windows only)
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
       # optionally set up Z3
       - if: ${{ inputs.setup-z3 }}
         name: Setup Z3

--- a/.github/workflows/reusable-qiskit-upstream.yml
+++ b/.github/workflows/reusable-qiskit-upstream.yml
@@ -37,9 +37,6 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
-      # Set up MSVC development environment (Windows only)
-      - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1
-
       # Optionally set up Z3
       - if: ${{ inputs.setup-z3 }}
         name: Setup Z3


### PR DESCRIPTION
The `msvc-dev-cmd` does not work properly (yet) on the new Windows 11 ARM runners.
Testing over at MQT Core has shown that the action is not actually needed for our CI, so we might as well remove it.