### PR TITLE
🔧 Use MSVC generator for Windows builds over Ninja

### DIFF
--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -26,7 +26,6 @@ on:
         description: >
           The compiler to use. Defaults to 'msvc'.
           This can be 'msvc' or 'clang'.
-          If 'msvc' is selected, '-G Ninja' is automatically added to the CMake arguments.
           If 'clang' is selected, '-T ClangCL' is automatically added to the CMake arguments.
         default: "msvc"
         type: string
@@ -73,9 +72,7 @@ jobs:
       - name: Configure CMake
         run: |
           cmake_args="${{ inputs.cmake-args }}"
-          if [ "${{ inputs.compiler }}" == "msvc" ]; then
-            cmake_args="$cmake_args -G Ninja"
-          elif [ "${{ inputs.compiler }}" == "clang" ]; then
+          if [ "${{ inputs.compiler }}" == "clang" ]; then
             cmake_args="$cmake_args -T ClangCL"
           fi
           cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ inputs.config }} $cmake_args

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 ### Changed
 
 - 🚸 Allow configuring the runners enabled for Python packaging ([#96]) ([**@burgholzer**])
+- 🔧 Use MSVC generator for Windows builds over Ninja ([#102]) ([**@burgholzer**])
 
 ### Removed
 
@@ -33,9 +34,10 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#102]: https://github.com/munich-quantum-toolkit/workflows/pull/102
+[#100]: https://github.com/munich-quantum-toolkit/workflows/pull/100
 [#96]: https://github.com/munich-quantum-toolkit/workflows/pull/96
 [#95]: https://github.com/munich-quantum-toolkit/workflows/pull/95
-[#100]: https://github.com/munich-quantum-toolkit/workflows/pull/100
 
 <!-- Contributor -->
 


### PR DESCRIPTION
## Description

In light of the new Windows 11 ARM runners, this PR switches from using the Ninja generator for the CI on Windows to using the MSVC generator.

## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
