### PR TITLE
🚨 Add Support for Linting Python Bindings

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -95,7 +95,7 @@ jobs:
       # set up uv for faster Python package management
       - if: ${{ inputs.setup-pybind11 }}
         name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
         with:
           python-version: 3.13
           activate-environment: true

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -44,7 +44,7 @@ on:
         type: boolean
       install-pkgs:
         description: "Packages to install in the Python virtual environment as a comma-separated list"
-        default: "pybind11"
+        default: ""
         type: string
 
 jobs:

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -43,7 +43,7 @@ on:
         default: false
         type: boolean
       install-pkgs:
-        description: "Packages to install in the Python virtual environment as a space-separated list"
+        description: "Packages to install in the Python virtual environment as a comma-separated list"
         default: "pybind11"
         type: string
 
@@ -106,7 +106,15 @@ jobs:
       # install the given packages in the Python virtual environment
       - if: ${{ inputs.setup-python }}
         name: Install given packages
-        run: uv pip install ${{ inputs.install-pkgs }}
+        run: |
+          pkgs="${{ inputs.install-pkgs }}"
+          if [[ ! "$pkgs" =~ ^[a-zA-Z0-9._\-, ]+$ ]]; then
+            echo "Invalid package list"
+            exit 1
+          fi
+          pkgs_array=()
+          IFS=',' read -ra pkgs_array <<< "$pkgs"
+          uv pip install "${pkgs_array[@]}"
       # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
         run: |

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -127,7 +127,7 @@ jobs:
           style: ""
           tidy-checks: ""
           version: ${{ env.clang-version }}
-          ignore: "build|!build/mlir/**|**/python|**/include|include"
+          ignore: "build|!build/mlir/**|**/python|python|**/include|include"
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
           step-summary: true
           database: "build"

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -38,10 +38,14 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.4"
         type: string
-      setup-pybind11:
-        description: "Whether to setup and activate a Python virtual environment with pybind11 installed"
+      setup-python:
+        description: "Whether to setup and activate a Python virtual environment"
         default: false
         type: boolean
+      install-pkgs:
+        description: "Packages to install in the Python virtual environment as a space-separated list"
+        default: "pybind11"
+        type: string
 
 jobs:
   lint:
@@ -93,16 +97,16 @@ jobs:
         name: Set up mold as linker
         uses: rui314/setup-mold@e16410e7f8d9e167b74ad5697a9089a35126eb50 # v1
       # set up uv for faster Python package management
-      - if: ${{ inputs.setup-pybind11 }}
+      - if: ${{ inputs.setup-python }}
         name: Install the latest version of uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6.1.0
         with:
           python-version: 3.13
           activate-environment: true
-      # install pybind11 for the cmake build to find its headers
-      - if: ${{ inputs.setup-pybind11 }}
-        name: Install pybind11
-        run: uv pip install pybind11
+      # install the given packages in the Python virtual environment
+      - if: ${{ inputs.setup-python }}
+        name: Install given packages
+        run: uv pip install ${{ inputs.install-pkgs }}
       # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
         run: |

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -127,7 +127,7 @@ jobs:
           style: ""
           tidy-checks: ""
           version: ${{ env.clang-version }}
-          ignore: "build|!build/mlir/**|**/python|python|**/include|include"
+          ignore: "build|!build/mlir/**|**/include|include"
           thread-comments: ${{ github.event_name == 'pull_request' && 'update' }}
           step-summary: true
           database: "build"

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -39,7 +39,7 @@ on:
         default: "4.13.4"
         type: string
       setup-pybind11:
-        description: "Whether to setup a python venv with pybind11"
+        description: "Whether to setup and activate a Python virtual environment with pybind11 installed"
         default: false
         type: boolean
 

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -38,6 +38,10 @@ on:
         description: "The version of Z3 to set up"
         default: "4.13.4"
         type: string
+      setup-pybind11:
+        description: "Whether to setup a python venv with pybind11"
+        default: false
+        type: boolean
 
 jobs:
   lint:
@@ -88,6 +92,17 @@ jobs:
       - if: ${{ inputs.build-project }}
         name: Set up mold as linker
         uses: rui314/setup-mold@e16410e7f8d9e167b74ad5697a9089a35126eb50 # v1
+      # set up uv for faster Python package management
+      - if: ${{ inputs.setup-pybind11 }}
+        name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: 3.13
+          activate-environment: true
+      # install pybind11 for the cmake build to find its headers
+      - if: ${{ inputs.setup-pybind11 }}
+        name: Install pybind11
+        run: uv pip install pybind11
       # generate a compilation database (assumes that the CMake project has `CMAKE_EXPORT_COMPILE_COMMANDS` set)
       - name: Generate compilation database
         run: |

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -105,10 +105,10 @@ jobs:
           activate-environment: true
       # install the given packages in the Python virtual environment
       - if: ${{ inputs.setup-python }}
-        name: Install given packages
+        name: Validate package list and install given packages
         run: |
           pkgs="${{ inputs.install-pkgs }}"
-          if [[ ! "$pkgs" =~ ^[a-zA-Z0-9._\-, ]+$ ]]; then
+          if [[ ! "$pkgs" =~ ^[a-zA-Z0-9=._-]+(,[a-zA-Z0-9=._-]+)*$ ]]; then
             echo "Invalid package list"
             exit 1
           fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ### Changed
 
-- 🚨 Add support for linting python bindings ([#114]) ([**@ystade**])
+- 🚨 Add support for linting Python bindings with clang-tidy ([#114]) ([**@ystade**])
 
 ## [1.9.0] - 2025-04-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Changed
+
+- 🚨 Add support for linting python bindings ([#114]) ([**@ystade**])
+
 ## [1.9.0] - 2025-04-26
 
 ### Added
@@ -34,6 +38,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#114]: https://github.com/munich-quantum-toolkit/workflows/pull/114
 [#102]: https://github.com/munich-quantum-toolkit/workflows/pull/102
 [#100]: https://github.com/munich-quantum-toolkit/workflows/pull/100
 [#96]: https://github.com/munich-quantum-toolkit/workflows/pull/96
@@ -42,6 +47,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 <!-- Contributor -->
 
 [**@burgholzer**]: https://github.com/burgholzer
+[**@ystade**]: https://github.com/ystade
 
 <!-- General links -->
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,7 +10,7 @@ When enabled, the Python environment is activated automatically such that CMake 
 
 This change includes that all `python` subdirectories are not ignored by the linter anymore. This may result in new warnings
 when the bindings are changed. To fix this, enable the option `setup-pybind11` of the `reusable-cpp-linter.yml` workflow
-and add the additional CMake argument `cmake-args: -DBUILD_MQT_[project]_BINDINGS=ON` to the `reusable-cpp-linter.yml` workflow where
+and add the additional workflow argument `cmake-args: -DBUILD_MQT_[project]_BINDINGS=ON` to the `reusable-cpp-linter.yml` workflow step where
 `[project]` is the name of the project you want to build. This will ensure that the bindings are built and the warnings are
 resolved.
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,7 +11,7 @@ When enabled, the Python environment is activated automatically such that CMake 
 This change includes that all `python` subdirectories are not ignored by the linter anymore. This may result in new warnings
 when the bindings are changed. To fix this, enable the option `setup-pybind11` of the `reusable-cpp-linter.yml` workflow
 and add the additional CMake argument `cmake-args: -DBUILD_MQT_[project]_BINDINGS=ON` to the `reusable-cpp-linter.yml` workflow where
-`[project]` is the name of the project you want to build. This will ensure that the bindings are built and the warnings are 
+`[project]` is the name of the project you want to build. This will ensure that the bindings are built and the warnings are
 resolved.
 
 ## [1.9.0]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,16 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
+This release adds support for linting Python bindings. To this end, the `reusable-cpp-linter.yml` workflow adds the option
+`setup-pybind11` to set up a Python environment and install the `pybind11` package. By default, this option is disabled.
+When enabled, the Python environment is activated automatically such that CMake will find the `pybind11` package.
+
+This change includes that all `python` subdirectories are not ignored by the linter anymore. This may result in new warnings
+when the bindings are changed. To fix this, enable the option `setup-pybind11` of the `reusable-cpp-linter.yml` workflow
+and add the additional CMake argument `cmake-args: -DBUILD_MQT_[project]_BINDINGS=ON` to the `reusable-cpp-linter.yml` workflow where
+`[project]` is the name of the project you want to build. This will ensure that the bindings are built and the warnings are 
+resolved.
+
 ## [1.9.0]
 
 This release adds support for the new Windows 11 ARM runners.


### PR DESCRIPTION
## Description

Previously, the `cpp` files containing the Python bindings were excluded from linting because this led to a couple of errors since the pybind11 headers were not available. The respective workflow now offers the optional setting to set up a Python environment and install pybind11. This can then be automatically caught up by the CMake configuration.

## Checklist:

- [x] The pull request only contains commits that are focused and relevant to this change.
- [ ] I have added appropriate tests that cover the new/changed functionality.
- [ ] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
