### PR TITLE
🐍🚨 Add support for running Astral's `ty` type checker

### DIFF
--- a/.github/workflows/reusable-python-linter.yml
+++ b/.github/workflows/reusable-python-linter.yml
@@ -10,6 +10,14 @@ name: 🐍 • Lint
 on:
   workflow_call:
     inputs:
+      enable-ty:
+        description: "Whether to enable Astral's ty for type checking"
+        default: false
+        type: boolean
+      enable-mypy:
+        description: "Whether to enable mypy for type checking"
+        default: true
+        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -48,8 +56,14 @@ jobs:
       # set up uv for faster Python package management
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@f0ec1fc3b38f5e7cd731bb6ce540c5af426746bb # v6
+      # run mypy for static type checking
       - name: Run mypy
+        if: ${{ inputs.enable-mypy }}
         run: uvx --with pre-commit-uv pre-commit run -a mypy
+      # run ty for type checking
+      - name: Run ty
+        if: ${{ inputs.enable-ty }}
+        run: uvx ty check
       # run check-sdist to ensure the package sdist is correct
       - name: Run check-sdist
         run: uvx check-sdist --inject-junk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ This project adheres to [Semantic Versioning], with the exception that minor rel
 
 ## [Unreleased]
 
+### Added
+
+- 🐍🚨 Add support for running Astral's `ty` type checker as part of the `reusable-python-linter.yml` workflow ([#128]) ([**@burgholzer**])
+
+### Changed
+
+- 🐍🚨 Update `reusable-python-linter.yml` to allow disabling the `mypy` type checker ([#128]) ([**@burgholzer**])
+
 ## [1.11.0] - 2025-06-15
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#1110)._

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,11 @@ Additionally, the `mypy` type checker can now be disabled by setting the `run-my
 While `ty` is a drop-in replacement for `mypy`, it is still in alpha and may not be as stable as `mypy`.
 The current recommendation is to use `ty` and `mypy` in parallel, as they may catch different issues.
 Once `ty` is stable, it can be used as a drop-in replacement for `mypy`.
+Project may want to add `ty` to their development dependencies to ensure that the same version is used for all developers.
+
+```commandline
+uv add --dev ty
+```
 
 ## [1.11.0]
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,13 @@ This document describes breaking changes and how to upgrade. For a complete list
 
 ## [Unreleased]
 
+This release adds support for running Astral's `ty` type checker as part of the `reusable-python-linter.yml` workflow.
+To enable this, you can set the `run-ty` option to `true` in the workflow configuration.
+Additionally, the `mypy` type checker can now be disabled by setting the `run-mypy` option to `false`.
+While `ty` is a drop-in replacement for `mypy`, it is still in alpha and may not be as stable as `mypy`.
+The current recommendation is to use `ty` and `mypy` in parallel, as they may catch different issues.
+Once `ty` is stable, it can be used as a drop-in replacement for `mypy`.
+
 ## [1.11.0]
 
 This release adapts the file filter for the change detection to the new project structure regarding the Python bindings.


### PR DESCRIPTION
## Description

This PR adds support for running Astral's `ty` type checker as part of the `reusable-python-linter.yml` workflow.
To enable this, you can set the `run-ty` option to `true` in the workflow configuration.
Additionally, the `mypy` type checker can now be disabled by setting the `run-mypy` option to `false`.
While `ty` is a drop-in replacement for `mypy`, it is still in alpha and may not be as stable as `mypy`.
The current recommendation is to use `ty` and `mypy` in parallel, as they may catch different issues.
Once `ty` is stable, it can be used as a drop-in replacement for `mypy`.
Project may want to add `ty` to their development dependencies to ensure that the same version is used for all developers.

```commandline
uv add --dev ty
```
## Checklist:

<!---
This checklist serves as a reminder of a couple of things that ensure your pull request will be merged swiftly.
-->

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.
