### PR TITLE
⚡️ Speed up reusable Python test builds

### DIFF
--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -79,6 +79,84 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up MSVC
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $vsArch = switch ($env:RUNNER_ARCH) {
+            'X64' { 'amd64' }
+            'ARM64' { 'arm64' }
+            default { throw "Unsupported Windows runner architecture: $env:RUNNER_ARCH" }
+          }
+          $component = switch ($env:RUNNER_ARCH) {
+            'X64' { 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' }
+            'ARM64' { 'Microsoft.VisualStudio.Component.VC.Tools.ARM64' }
+          }
+
+          $candidates = @(
+            if (${env:ProgramFiles(x86)}) {
+              Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+            }
+            if ($env:ProgramFiles) {
+              Join-Path $env:ProgramFiles 'Microsoft Visual Studio\Installer\vswhere.exe'
+            }
+            Get-Command vswhere.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+          )
+          $vswhere = $candidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+          if (-not $vswhere) {
+            throw 'vswhere.exe not found'
+          }
+
+          $vsPath = (& $vswhere -latest -products '*' -prerelease -requires $component -property installationPath | Select-Object -First 1)
+          if (-not $vsPath) {
+            throw "Visual Studio with $component not found"
+          }
+          $devShell = Join-Path $vsPath 'Common7\Tools\Launch-VsDevShell.ps1'
+          if (-not (Test-Path $devShell)) {
+            throw "Developer shell not found: $devShell"
+          }
+
+          $before = @{}
+          Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
+          $devShellArguments = @{
+            Arch = $vsArch
+            SkipAutomaticLocation = $true
+          }
+          if ($env:RUNNER_ARCH -eq 'X64') {
+            $devShellArguments.HostArch = 'amd64'
+          }
+          & $devShell @devShellArguments
+
+          $compiler = (Get-Command cl.exe -ErrorAction Stop).Source
+          $expected = if ($env:RUNNER_ARCH -eq 'ARM64') { '\Hostarm64\arm64\' } else { '\Hostx64\x64\' }
+          if ($compiler -notmatch [regex]::Escape($expected)) {
+            throw "Unexpected MSVC compiler for $($env:RUNNER_ARCH): $compiler"
+          }
+          Write-Host "Using $compiler"
+
+          Get-ChildItem Env: | ForEach-Object {
+            if (
+              (!$before.ContainsKey($_.Name) -or $before[$_.Name] -cne $_.Value) -and
+              $_.Name -notmatch '^(GITHUB_|RUNNER_)' -and
+              $_.Name -ne 'NODE_OPTIONS'
+            ) {
+              $delimiter = "ghadelimiter_$([guid]::NewGuid().ToString('N'))"
+              Add-Content -Path $env:GITHUB_ENV -Value "$($_.Name)<<$delimiter" -Encoding utf8
+              Add-Content -Path $env:GITHUB_ENV -Value $_.Value -Encoding utf8
+              Add-Content -Path $env:GITHUB_ENV -Value $delimiter -Encoding utf8
+            }
+          }
+
+      - name: Configure Windows native builds
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
+          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+
       - name: Set up Z3
         if: ${{ inputs.setup-z3 }}
         uses: cda-tum/setup-z3@7bfe87519f27304460db44284cb8cc59f50f5fc9 # v1.7.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-07-29
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#221)._
+
+### Changed
+
+- ⚡️ Initialize native MSVC and use Ninja to activate job-local `sccache` in
+  Windows Python test jobs ([#417]) ([**@burgholzer**])
+
 ## [2.2.0] - 2026-06-22
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#220)._
@@ -424,7 +433,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.1
 [2.2.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.0
 [2.1.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.1.1
 [2.1.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.1.0
@@ -465,6 +475,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#417]: https://github.com/munich-quantum-toolkit/workflows/pull/417
 [#400]: https://github.com/munich-quantum-toolkit/workflows/pull/400
 [#395]: https://github.com/munich-quantum-toolkit/workflows/pull/395
 [#392]: https://github.com/munich-quantum-toolkit/workflows/pull/392

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,23 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+## [2.2.1]
+
+On Windows, `reusable-python-tests.yml` now initializes native MSVC and uses
+Ninja so the installed, job-local `sccache` can reuse compiler results between
+Python sessions. Compiler results are not stored between jobs or workflow runs.
+Linux and macOS setup is unchanged.
+
+To reuse a native build tree between nox sessions, projects may configure a
+shared directory in `pyproject.toml`, for example:
+
+```toml
+[tool.scikit-build]
+build-dir = "build/python/{build_type}"
+```
+
+Keep this directory separate from CMake preset build directories.
+
 ## [2.2.0]
 
 This release adds a `run-python-linter` output to
@@ -594,7 +611,8 @@ invocations under Windows.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.1.0...v2.2.0
 [2.1.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.3...v2.1.0
 [2.0.3]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.0.2...v2.0.3


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Summary

- Initialize the native MSVC environment in Windows Python test jobs.
- Use Ninja so CMake invokes the existing job-local sccache installation.
- Document project-owned shared scikit-build-core build directories.
- Prepare the v2.2.1 patch release, dated 2026-07-29.

Linux, macOS, and all packaging workflows remain unchanged. No compiler cache is persisted between jobs or workflow runs.

## Rationale

The Visual Studio generator bypassed CMake compiler launchers, so installing sccache alone produced no compiler requests. Selecting Ninja after initializing the architecture-appropriate MSVC environment activates the launcher.

Projects can share a native build tree across nox sessions with:

```toml
[tool.scikit-build]
build-dir = "build/python/{build_type}"
```

## Evidence

The test-only configuration passed on macOS and Windows in [MQT Core run 30404816970](https://github.com/munich-quantum-toolkit/core/actions/runs/30404816970). On Windows, the five minimum-resolution sessions took 15m, 2m, 2m, 27s, and 17s; all five regular-resolution sessions then completed in 47s. sccache reported a 35.93% hit rate.

## Validation

- [x] Full reusable-workflows hook suite, including workflow validation and zizmor
- [x] MQT Core lockfile and lint checks
- [x] Windows and macOS reusable Python test jobs
- [x] Changelog and upgrade guide updated
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
