### PR TITLE
📝 Document cibuildwheel v4 migration cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Changed
+
+- 📝 Document the cibuildwheel v4 configuration cleanup for consumers ([#424])
+  ([**@burgholzer**])
+
 ## [2.2.1] - 2026-07-29
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#221)._
@@ -475,6 +480,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#424]: https://github.com/munich-quantum-toolkit/workflows/pull/424
 [#417]: https://github.com/munich-quantum-toolkit/workflows/pull/417
 [#400]: https://github.com/munich-quantum-toolkit/workflows/pull/400
 [#395]: https://github.com/munich-quantum-toolkit/workflows/pull/395

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,20 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+The reusable Python packaging workflow uses cibuildwheel v4. Consumers can
+simplify their cibuildwheel configuration:
+
+- Remove `cp313t-*` skip selectors. cibuildwheel v4 no longer supports CPython
+  3.13 free-threaded builds, while CPython 3.14 free-threaded builds remain
+  supported.
+- Remove overrides that append `uvx abi3audit --strict --report {wheel}` to the
+  repair command. cibuildwheel v4 audits ABI3 wheels by default.
+- Remove explicit `manylinux_2_28` image settings when the project does not need
+  a custom image. This is cibuildwheel v4's default.
+
+Generic free-threaded test skips such as `cp3??t-*` may still be needed when
+test dependencies do not provide free-threaded wheels.
+
 ## [2.2.1]
 
 On Windows, `reusable-python-tests.yml` now initializes native MSVC and uses


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Document the consumer-side cleanup enabled by the reusable packaging workflow's
move to cibuildwheel v4:

- remove the unsupported `cp313t-*` selector while retaining dependency-driven
  free-threaded test skips;
- rely on cibuildwheel's built-in ABI3 audit instead of appending a duplicate
  repair command;
- rely on cibuildwheel v4's implicit `manylinux_2_28` images unless a project
  needs a custom image.

## Validation

- `uvx prek run -a`
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to
  this change.
- [x] Tests are not applicable to this documentation-only change.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added an entry to the changelog.
- [x] I have added migration instructions to the upgrade guide.
- [x] The changes follow the project's style guidelines and introduce no new
  warnings.
- [x] The local validation checks pass.
- [x] I have reviewed the proposed changes.

**If PR contains AI-assisted content:**

- [x] The agent was explicitly authorized to create these pull requests.
- [x] This body begins with the required visible disclosure.
- [x] The AI-assisted commit includes an
  `Assisted-by: GPT-5.6 via Codex` footer.
- [x] I confirm that I have personally reviewed and understood all AI-generated
  content, and accept full responsibility for it.
