### PR TITLE
🔐 Allow explicit AWS secrets in wheel workflows

### DIFF
--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -31,6 +31,16 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+    secrets:
+      AWS_S3_BUCKET:
+        description: "S3 bucket used by AWS-backed wheel tests"
+        required: false
+      AWS_ACCESS_KEY_ID:
+        description: "AWS access key ID used by wheel tests"
+        required: false
+      AWS_SECRET_ACCESS_KEY:
+        description: "AWS secret access key used by wheel tests"
+        required: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-python-packaging-cibw-${{ inputs.runs-on }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ releases may include breaking changes.
 ### Added
 
 - 🔐 Allow cross-organization callers to pass AWS and S3 secrets explicitly to
-  the reusable `cibuildwheel` workflow ([**@burgholzer**])
+  the reusable `cibuildwheel` workflow ([#432]) ([**@burgholzer**])
 
 ## [2.2.2] - 2026-08-05
 
@@ -491,6 +491,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#432]: https://github.com/munich-quantum-toolkit/workflows/pull/432
 [#430]: https://github.com/munich-quantum-toolkit/workflows/pull/430
 [#424]: https://github.com/munich-quantum-toolkit/workflows/pull/424
 [#417]: https://github.com/munich-quantum-toolkit/workflows/pull/417

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Added
+
+- 🔐 Allow cross-organization callers to pass AWS and S3 secrets explicitly to
+  the reusable `cibuildwheel` workflow ([**@burgholzer**])
+
 ## [2.2.2] - 2026-08-05
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#222)._

--- a/README.md
+++ b/README.md
@@ -41,6 +41,17 @@ whitelist of inherited secrets as environment variables. In the calling
 workflow, use `secrets: inherit` and define the corresponding repository or
 environment secrets with the same names.
 
+Secret inheritance is limited to callers in the same organization or enterprise.
+Cross-organization callers of `reusable-python-packaging-wheel-cibuildwheel.yml`
+can instead pass the AWS secrets explicitly:
+
+```yaml
+secrets:
+  AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+```
+
 The currently supported variables are
 
 - `IQM_TOKEN`,


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Declare `AWS_S3_BUCKET`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` as
optional callable secrets of the reusable `cibuildwheel` workflow. The workflow
already exposes these names to wheel builds; declaring them allows a caller in
another GitHub organization to map its repository secrets explicitly.

This preserves `secrets: inherit` for existing callers in the same organization
or enterprise and preserves empty values when a caller, including a fork, does
not supply the optional secrets.

The README documents both calling forms. The change is required by
[Amazon Braket QDMI PR #168](https://github.com/munich-quantum-software/amazon-braket-qdmi-device/pull/168),
whose secret-enabled manylinux CPython 3.14 wheel test runs a cost-capped Amazon
SV1 PennyLane smoke test.

AI assistance was used to inspect the failed cross-organization workflow call,
prepare the narrowly scoped workflow and documentation changes, and run the
repository validation suite.

## Validation

- GitHub workflow schema validation
- Prettier and Markdown formatting
- typo and license checks
- zizmor with the repository's pedantic configuration
- `git diff --check`

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have updated the documentation to reflect these changes.
- [x] I have added an entry to the changelog.
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope.
- [x] Every agent-authored public text body begins with the required visible disclosure.
- [x] I have disclosed AI assistance in the PR description.
