### PR TITLE
🐛 Fix name of Windows coverage report in `reusable-python-tests.yml`

### DIFF
--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -183,12 +183,16 @@ jobs:
 
       # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
       - name: 🐍 Test with minimal versions
+        # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
+        shell: bash
         env:
           RUNS_ON: ${{ inputs.runs-on }}
         run: uvx nox -s minimums --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
 
       # run the nox tests session (assumes a nox session named "tests" exists) with coverage
       - name: 🐍 Test
+        # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
+        shell: bash
         env:
           RUNS_ON: ${{ inputs.runs-on }}
         run: uvx nox -s tests --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ releases may include breaking changes.
 - 🔐 Allow cross-organization callers to pass AWS and S3 secrets explicitly to
   the reusable `cibuildwheel` workflow ([#432]) ([**@burgholzer**])
 
+### Fixed
+
+- 🐛 Name the Windows coverage report after the platform it was created on
+  ([#433]) ([**@denialhaag**])
+
 ## [2.2.2] - 2026-08-05
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#222)._
@@ -491,6 +496,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#433]: https://github.com/munich-quantum-toolkit/workflows/pull/433
 [#432]: https://github.com/munich-quantum-toolkit/workflows/pull/432
 [#430]: https://github.com/munich-quantum-toolkit/workflows/pull/430
 [#424]: https://github.com/munich-quantum-toolkit/workflows/pull/424


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The test steps pass `--cov-report=xml:coverage-$RUNS_ON.xml` to `nox`. On Windows, the default shell is PowerShell, where `$RUNS_ON` expands to an empty string, so the report is written to `coverage-.xml` instead of, e.g., `coverage-windows-2025.xml`. The artifact is named correctly, so this only surfaces downstream, where `reusable-python-coverage.yml` uploads a nameless report to Codecov.

Running both steps with `bash` expands the variable on all platforms. `$RUNS_ON` stays an environment variable to avoid a template injection finding.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
