### PR TITLE
🐛 Consider deleted files in change detection

### DIFF
--- a/.github/workflows/reusable-change-detection.yml
+++ b/.github/workflows/reusable-change-detection.yml
@@ -90,7 +90,7 @@ jobs:
       - name: Set a flag for running the C++ tests
         if: >-
           github.event_name != 'pull_request'
-          || steps.changed-cpp-testable-files.outputs.added_modified_renamed != ''
+          || steps.changed-cpp-testable-files.outputs.all != ''
         id: cpp-tests-changes
         run: >-
           echo "run-cpp-tests=true" >> "${GITHUB_OUTPUT}"
@@ -115,7 +115,7 @@ jobs:
       - name: Set a flag for running the C++ linter
         if: >-
           github.event_name != 'pull_request'
-          || steps.changed-cpp-linter-files.outputs.added_modified_renamed != ''
+          || steps.changed-cpp-linter-files.outputs.all != ''
         id: cpp-linter-changes
         run: >-
           echo "run-cpp-linter=true" >> "${GITHUB_OUTPUT}"
@@ -147,7 +147,7 @@ jobs:
       - name: Set a flag for running the Python tests
         if: >-
           github.event_name != 'pull_request'
-          || steps.changed-python-testable-files.outputs.added_modified_renamed != ''
+          || steps.changed-python-testable-files.outputs.all != ''
         id: python-tests-changes
         run: >-
           echo "run-python-tests=true" >> "${GITHUB_OUTPUT}"
@@ -173,7 +173,7 @@ jobs:
       - name: Set a flag for running the Python linter
         if: >-
           github.event_name != 'pull_request'
-          || steps.changed-python-linter-files.outputs.added_modified_renamed != ''
+          || steps.changed-python-linter-files.outputs.all != ''
         id: python-linter-changes
         run: >-
           echo "run-python-linter=true" >> "${GITHUB_OUTPUT}"
@@ -190,7 +190,7 @@ jobs:
       - name: Set a flag for running the continuous deployment job
         if: >-
           github.event_name == 'pull_request'
-          && steps.changed-cd-files.outputs.added_modified_renamed != ''
+          && steps.changed-cd-files.outputs.all != ''
         id: cd-changes
         run: >-
           echo "run-cd=true" >> "${GITHUB_OUTPUT}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Consider deleted files in `reusable-change-detection.yml` ([#441])
+  ([**@denialhaag**])
+
 ## [2.2.3] - 2026-08-19
 
 ### Added
@@ -505,6 +510,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#441]: https://github.com/munich-quantum-toolkit/workflows/pull/441
 [#434]: https://github.com/munich-quantum-toolkit/workflows/pull/434
 [#433]: https://github.com/munich-quantum-toolkit/workflows/pull/433
 [#432]: https://github.com/munich-quantum-toolkit/workflows/pull/432


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Change detection uses the `added_modified_renamed` output of [Ana06/get-changed-files](https://github.com/Ana06/get-changed-files), which excludes deleted files. A pull request that only deletes relevant files therefore does not trigger the corresponding CI or CD jobs. This surfaced in munich-quantum-toolkit/core#2154, where removing the decision-diagram approximation header, implementation, and tests did not run the C++ CI.

Switch all five flags in `reusable-change-detection.yml` to the `all` output, which includes deleted files. The conditions only check whether the list is non-empty, so the fact that `all` also reports the old path of a renamed file makes no difference.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
