### PR TITLE
🐛 Sign and attribute the commits created by `reusable-mqt-core-update.yml`

### DIFF
--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -265,7 +265,7 @@ jobs:
               --field "sha=$COMMIT_OID" --field "force=true" >/dev/null
 
           # Open a pull request unless one is already open for this branch.
-          if [ -z "$(gh pr list --repo "$REPOSITORY" --head "$BRANCH_NAME" --state open --json number --jq '.[].number')" ]; then
+          if [ -z "$(gh pr list --repo "$REPOSITORY" --head "$BRANCH_NAME" --base "main" --state open --json number --jq '.[].number')" ]; then
             gh pr create \
               --repo "$REPOSITORY" \
               --title "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}" \

--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -195,11 +195,11 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.create-token.outputs.token }}
           REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
           USED_VERSION: ${{ steps.get-used-version.outputs.version }}
           USED_REVISION: ${{ steps.get-used-version.outputs.revision }}
           NEW_VERSION: ${{ steps.determine-new-version-and-revision.outputs.new_version }}
           NEW_REVISION: ${{ steps.determine-new-version-and-revision.outputs.new_revision }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -194,32 +194,72 @@ jobs:
         if: steps.compare-versions.outputs.update == 'true'
         env:
           GH_TOKEN: ${{ steps.create-token.outputs.token }}
-          APP_ID: ${{ secrets.APP_ID }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
+          REPOSITORY: ${{ github.repository }}
           USED_VERSION: ${{ steps.get-used-version.outputs.version }}
           USED_REVISION: ${{ steps.get-used-version.outputs.revision }}
           NEW_VERSION: ${{ steps.determine-new-version-and-revision.outputs.new_version }}
           NEW_REVISION: ${{ steps.determine-new-version-and-revision.outputs.new_revision }}
         run: |
-          git config --global user.name "mqt-app[bot]"
-          git config --global user.email "${APP_ID}+mqt-app[bot]@users.noreply.github.com"
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          set -euo pipefail
 
           BRANCH_NAME="update-mqt-core-${NEW_REVISION}"
-          git checkout -b "$BRANCH_NAME"
-          git commit -a -m "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}"
-          git push origin "$BRANCH_NAME" --force
 
-          cat <<EOF > pr_body.md
-          This pull request updates the [munich-quantum-toolkit/core](https://github.com/munich-quantum-toolkit/core) dependency from munich-quantum-toolkit/core@${USED_REVISION} (version v${USED_VERSION}) to munich-quantum-toolkit/core@${NEW_REVISION} (version v${NEW_VERSION}).
+          # Nothing to do if the update step did not change anything.
+          git add --all
+          if git diff --cached --quiet; then
+            echo "No changes to the MQT Core version or revision."
+            exit 0
+          fi
 
-          **Full Changelog**: https://github.com/munich-quantum-toolkit/core/compare/${USED_REVISION}...${NEW_REVISION}
-          EOF
+          # Point the pull request branch at the current base, so the commit below applies
+          # cleanly whether or not the branch already exists from an earlier run.
+          BASE_OID="$(git rev-parse HEAD)"
+          gh api "repos/$REPOSITORY/git/refs" \
+            --field "ref=refs/heads/$BRANCH_NAME" \
+            --field "sha=$BASE_OID" >/dev/null 2>&1 ||
+            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$BRANCH_NAME" \
+              --field "sha=$BASE_OID" --field "force=true" >/dev/null
 
-          gh pr create \
-            --title "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}" \
-            --body-file pr_body.md \
-            --base "main" \
-            --label "dependencies,c++" \
-            --head "$BRANCH_NAME" \
-            || true
+          # Commit through the GraphQL API so that GitHub signs the commit and attributes it
+          # to the app. `--no-renames` splits a rename into a deletion and an addition, so
+          # that the old path is removed rather than left behind.
+          ADDITIONS="$(git diff --cached --no-renames --name-only --diff-filter=ACM |
+            while IFS= read -r file; do
+              jq -n --arg path "$file" \
+                    --arg contents "$(base64 < "$file" | tr -d '\n')" \
+                    '{path: $path, contents: $contents}'
+            done | jq --slurp '.')"
+          DELETIONS="$(git diff --cached --no-renames --name-only --diff-filter=D |
+            jq --raw-input '{path: .}' | jq --slurp '.')"
+
+          jq -n \
+            --arg repository "$REPOSITORY" \
+            --arg branch "$BRANCH_NAME" \
+            --arg oid "$BASE_OID" \
+            --arg headline "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}" \
+            --argjson additions "$ADDITIONS" \
+            --argjson deletions "$DELETIONS" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { oid } } }",
+              variables: {
+                input: {
+                  branch: {repositoryNameWithOwner: $repository, branchName: $branch},
+                  message: {headline: $headline},
+                  expectedHeadOid: $oid,
+                  fileChanges: {additions: $additions, deletions: $deletions}
+                }
+              }
+            }' | gh api graphql --input - >/dev/null
+
+          # Open a pull request unless one is already open for this branch.
+          if [ -z "$(gh pr list --repo "$REPOSITORY" --head "$BRANCH_NAME" --state open --json number --jq '.[].number')" ]; then
+            gh pr create \
+              --repo "$REPOSITORY" \
+              --title "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}" \
+              --body "This pull request updates the [munich-quantum-toolkit/core](https://github.com/munich-quantum-toolkit/core) dependency from munich-quantum-toolkit/core@${USED_REVISION} (version v${USED_VERSION}) to munich-quantum-toolkit/core@${NEW_REVISION} (version v${NEW_VERSION}).
+
+          **Full Changelog**: https://github.com/munich-quantum-toolkit/core/compare/${USED_REVISION}...${NEW_REVISION}" \
+              --base "main" \
+              --head "$BRANCH_NAME" \
+              --label "dependencies,c++"
+          fi

--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -211,13 +211,19 @@ jobs:
             exit 0
           fi
 
-          # Point the pull request branch at the current base, so the commit below applies
-          # cleanly whether or not the branch already exists from an earlier run.
+          # Build the commit on a temporary branch, so that an already open pull request
+          # keeps its current commit if anything below fails.
           BASE_OID="$(git rev-parse HEAD)"
+          TEMPORARY_BRANCH="$BRANCH_NAME-tmp"
+          cleanup() {
+            gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$TEMPORARY_BRANCH" \
+              >/dev/null 2>&1 || true
+          }
+          trap cleanup EXIT
           gh api "repos/$REPOSITORY/git/refs" \
-            --field "ref=refs/heads/$BRANCH_NAME" \
+            --field "ref=refs/heads/$TEMPORARY_BRANCH" \
             --field "sha=$BASE_OID" >/dev/null 2>&1 ||
-            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$BRANCH_NAME" \
+            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$TEMPORARY_BRANCH" \
               --field "sha=$BASE_OID" --field "force=true" >/dev/null
 
           # Commit through the GraphQL API so that GitHub signs the commit and attributes it
@@ -232,9 +238,9 @@ jobs:
           DELETIONS="$(git diff --cached --no-renames --name-only --diff-filter=D |
             jq --raw-input '{path: .}' | jq --slurp '.')"
 
-          jq -n \
+          COMMIT_OID="$(jq -n \
             --arg repository "$REPOSITORY" \
-            --arg branch "$BRANCH_NAME" \
+            --arg branch "$TEMPORARY_BRANCH" \
             --arg oid "$BASE_OID" \
             --arg headline "⬆️ Update \`munich-quantum-toolkit/core\` from v${USED_VERSION} to v${NEW_VERSION}" \
             --argjson additions "$ADDITIONS" \
@@ -249,7 +255,15 @@ jobs:
                   fileChanges: {additions: $additions, deletions: $deletions}
                 }
               }
-            }' | gh api graphql --input - >/dev/null
+            }' | gh api graphql --input - \
+            --jq '.data.createCommitOnBranch.commit.oid')"
+
+          # Only now move the pull request branch onto the new commit.
+          gh api "repos/$REPOSITORY/git/refs" \
+            --field "ref=refs/heads/$BRANCH_NAME" \
+            --field "sha=$COMMIT_OID" >/dev/null 2>&1 ||
+            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$BRANCH_NAME" \
+              --field "sha=$COMMIT_OID" --field "force=true" >/dev/null
 
           # Open a pull request unless one is already open for this branch.
           if [ -z "$(gh pr list --repo "$REPOSITORY" --head "$BRANCH_NAME" --state open --json number --jq '.[].number')" ]; then

--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -185,7 +185,6 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.determine-new-version-and-revision.outputs.new_version }}
           NEW_REVISION: ${{ steps.determine-new-version-and-revision.outputs.new_revision }}
-          RUN_ID: ${{ github.run_id }}
         run: |
           sed -i "s|set(MQT_CORE_VERSION.*|set(MQT_CORE_VERSION $NEW_VERSION|" cmake/ExternalDependencies.cmake
           sed -i "s|set(MQT_CORE_REV.*|set(MQT_CORE_REV \"$NEW_REVISION\"|" cmake/ExternalDependencies.cmake
@@ -200,6 +199,7 @@ jobs:
           USED_REVISION: ${{ steps.get-used-version.outputs.revision }}
           NEW_VERSION: ${{ steps.determine-new-version-and-revision.outputs.new_version }}
           NEW_REVISION: ${{ steps.determine-new-version-and-revision.outputs.new_revision }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/reusable-mqt-core-update.yml
+++ b/.github/workflows/reusable-mqt-core-update.yml
@@ -185,6 +185,7 @@ jobs:
         env:
           NEW_VERSION: ${{ steps.determine-new-version-and-revision.outputs.new_version }}
           NEW_REVISION: ${{ steps.determine-new-version-and-revision.outputs.new_revision }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           sed -i "s|set(MQT_CORE_VERSION.*|set(MQT_CORE_VERSION $NEW_VERSION|" cmake/ExternalDependencies.cmake
           sed -i "s|set(MQT_CORE_REV.*|set(MQT_CORE_REV \"$NEW_REVISION\"|" cmake/ExternalDependencies.cmake
@@ -214,7 +215,7 @@ jobs:
           # Build the commit on a temporary branch, so that an already open pull request
           # keeps its current commit if anything below fails.
           BASE_OID="$(git rev-parse HEAD)"
-          TEMPORARY_BRANCH="$BRANCH_NAME-tmp"
+          TEMPORARY_BRANCH="$BRANCH_NAME-$RUN_ID"
           cleanup() {
             gh api --method DELETE "repos/$REPOSITORY/git/refs/heads/$TEMPORARY_BRANCH" \
               >/dev/null 2>&1 || true
@@ -222,9 +223,7 @@ jobs:
           trap cleanup EXIT
           gh api "repos/$REPOSITORY/git/refs" \
             --field "ref=refs/heads/$TEMPORARY_BRANCH" \
-            --field "sha=$BASE_OID" >/dev/null 2>&1 ||
-            gh api --method PATCH "repos/$REPOSITORY/git/refs/heads/$TEMPORARY_BRANCH" \
-              --field "sha=$BASE_OID" --field "force=true" >/dev/null
+            --field "sha=$BASE_OID" >/dev/null
 
           # Commit through the GraphQL API so that GitHub signs the commit and attributes it
           # to the app. `--no-renames` splits a rename into a deletion and an addition, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ releases may include breaking changes.
 
 ### Fixed
 
+- 🐛 Sign and attribute the commits created by `reusable-mqt-core-update.yml`
+  ([#442]) ([**@denialhaag**])
 - 🐛 Consider deleted files in `reusable-change-detection.yml` ([#441])
   ([**@denialhaag**])
 
@@ -510,6 +512,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#442]: https://github.com/munich-quantum-toolkit/workflows/pull/442
 [#441]: https://github.com/munich-quantum-toolkit/workflows/pull/441
 [#434]: https://github.com/munich-quantum-toolkit/workflows/pull/434
 [#433]: https://github.com/munich-quantum-toolkit/workflows/pull/433


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

The commits that `reusable-mqt-core-update.yml` produces are neither attributed to the app nor signed. The author and committer e-mail is built from `APP_ID`, which holds the app's client ID, whereas GitHub links a `users.noreply.github.com` address by the bot user's numeric ID. Both the author and the committer therefore show a default avatar instead of the app's, for example in munich-quantum-toolkit/qmap#1116. The commit is also unverified, because it is created locally with `git commit` rather than through the API.

This replaces that with the same approach [munich-quantum-toolkit/templates](https://github.com/munich-quantum-toolkit/templates) uses: the commit is created through the GraphQL `createCommitOnBranch` mutation, so GitHub signs it and attributes it to the app without the workflow having to construct an e-mail address at all. `APP_ID` is no longer needed outside of creating the token.

The two implementations are now identical apart from the commit message, the pull request title, body, base branch, and labels. Renames are committed as a deletion plus an addition so that the old path is removed rather than left behind, and the step does nothing when the update produced no changes.

The new script step cannot be exercised without a real token, so it is unverified until this workflow next runs.

## AI notice

This PR and its contents were created with the assistance of Opus 5 via Claude Code.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
