### PR TITLE
✨ Reduce test workloads for draft pull requests

### DIFF
--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -16,6 +16,10 @@ on:
           This can be any valid macOS runner image, such as 'macos-15', 'macos-26', or 'macos-26-intel'.
         default: "macos-latest"
         type: string
+      run-on-draft:
+        description: "Whether to run the tests for draft pull requests"
+        default: true
+        type: boolean
       compiler:
         description: >
           The compiler to use. Defaults to 'clang'.
@@ -55,6 +59,7 @@ permissions:
 
 jobs:
   cpp-tests-macos:
+    if: ${{ !github.event.pull_request.draft || inputs.run-on-draft }}
     name: 🍎 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -16,6 +16,10 @@ on:
           This can be any valid Ubuntu runner image, such as 'ubuntu-24.04' or its ARM variant 'ubuntu-24.04-arm'.
         default: "ubuntu-24.04"
         type: string
+      run-on-draft:
+        description: "Whether to run the tests for draft pull requests"
+        default: true
+        type: boolean
       compiler:
         description: >
           The compiler to use. Defaults to 'gcc'.
@@ -55,6 +59,7 @@ permissions:
 
 jobs:
   cpp-tests-ubuntu:
+    if: ${{ !github.event.pull_request.draft || inputs.run-on-draft }}
     name: 🐧 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -16,6 +16,10 @@ on:
           This can be any valid Windows runner image, such as 'windows-2022' or 'windows-2025'.
         default: "windows-latest"
         type: string
+      run-on-draft:
+        description: "Whether to run the tests for draft pull requests"
+        default: true
+        type: boolean
       compiler:
         description: >
           The compiler to use. Defaults to 'msvc'.
@@ -61,6 +65,7 @@ defaults:
 
 jobs:
   cpp-tests-windows:
+    if: ${{ !github.event.pull_request.draft || inputs.run-on-draft }}
     name: 🏁 ${{ inputs.runs-on }} ${{ inputs.compiler }} ${{ inputs.preset-name }}
     runs-on: ${{ inputs.runs-on }}
     env:

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -14,6 +14,14 @@ on:
         description: "The platform to run the tests on"
         required: true
         type: string
+      sessions:
+        description: "The Nox sessions to run for ready pull requests and non-pull-request events, formatted as a JSON array"
+        default: '["minimums", "tests"]'
+        type: string
+      draft-sessions:
+        description: "The Nox sessions to run for draft pull requests, formatted as a JSON array"
+        default: '["tests-3.14"]'
+        type: string
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -181,21 +189,23 @@ jobs:
       - name: Install sccache
         run: uv tool install sccache
 
-      # run the nox minimums session (assumes a nox session named "minimums" exists) with coverage
-      - name: 🐍 Test with minimal versions
-        # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
-        shell: bash
-        env:
-          RUNS_ON: ${{ inputs.runs-on }}
-        run: uvx nox -s minimums --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
-
-      # run the nox tests session (assumes a nox session named "tests" exists) with coverage
       - name: 🐍 Test
+        if: ${{ !github.event.pull_request.draft }}
         # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
         shell: bash
         env:
           RUNS_ON: ${{ inputs.runs-on }}
-        run: uvx nox -s tests --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
+          SESSIONS: ${{ join(fromJSON(inputs.sessions), ' ') }}
+        run: uvx nox -s $SESSIONS --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
+
+      - name: 🐍 Test draft
+        if: ${{ github.event.pull_request.draft }}
+        # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
+        shell: bash
+        env:
+          RUNS_ON: ${{ inputs.runs-on }}
+          SESSIONS: ${{ join(fromJSON(inputs.draft-sessions), ' ') }}
+        run: uvx nox -s $SESSIONS --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
 
       # upload the report as an artifact to GitHub so that it can later be uploaded to Codecov
       - name: Upload 🐍 coverage report for ${{ inputs.runs-on }}

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -189,8 +189,8 @@ jobs:
       - name: Install sccache
         run: uv tool install sccache
 
-      - name: 🐍 Test
-        if: ${{ !github.event.pull_request.draft }}
+      - if: ${{ !github.event.pull_request.draft }}
+        name: 🐍 Test
         # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
         shell: bash
         env:
@@ -198,8 +198,8 @@ jobs:
           SESSIONS: ${{ join(fromJSON(inputs.sessions), ' ') }}
         run: uvx nox -s $SESSIONS --verbose -- --cov --cov-report=xml:coverage-$RUNS_ON.xml --cov-append
 
-      - name: 🐍 Test draft
-        if: ${{ github.event.pull_request.draft }}
+      - if: ${{ github.event.pull_request.draft }}
+        name: 🐍 Test
         # `bash` is required so that `$RUNS_ON` is expanded on Windows, too
         shell: bash
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,15 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [2.3.0] - 2026-08-24
+
+_If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#230)._
+
+### Added
+
+- ✨ Allow callers to reduce Python and C++ tests for draft pull requests
+  ([#443]) ([**@denialhaag**])
+
 ### Fixed
 
 - 🐛 Sign and attribute the commits created by `reusable-mqt-core-update.yml`
@@ -468,7 +477,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.3...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.0
 [2.2.3]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.3
 [2.2.2]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.2
 [2.2.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.1

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,72 @@ of changes, including minor and patch releases, please refer to the
 
 ## [Unreleased]
 
+## [2.3.0]
+
+The Python test workflow now accepts `sessions` and `draft-sessions` as
+JSON-formatted lists of Nox sessions. `sessions` is used for ready pull requests
+and non-pull-request events and defaults to `["minimums", "tests"]`.
+`draft-sessions` is used for draft pull requests and defaults to
+`["tests-3.14"]`.
+
+For example, the following matrix runs the `tests` session for every supported
+Python version on ready pull requests and other events, but only the Python 3.14
+session on drafts:
+
+```yaml
+python-tests:
+  name: 🐍 Test
+  strategy:
+    fail-fast: false
+    matrix:
+      runs-on:
+        [
+          ubuntu-24.04,
+          ubuntu-24.04-arm,
+          macos-26,
+          macos-26-intel,
+          windows-2025,
+        ]
+  uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-python-tests.yml@v2.3.0
+  with:
+    runs-on: ${{ matrix.runs-on }}
+    sessions: '["tests"]'
+    draft-sessions: '["tests-3.14"]'
+```
+
+The C++ test workflows for Ubuntu, macOS, and Windows now accept a
+`run-on-draft` input. It defaults to `true` for backward compatibility. Set it
+to `false` for jobs that should be skipped entirely on draft pull requests, such
+as release builds or a Linux x86 build already covered by the coverage job. A
+matrix can select this per configuration.
+
+For example, this Linux matrix skips its x86 debug build because it is covered
+by the coverage job and its ARM release build because it is not needed on
+drafts:
+
+```yaml
+cpp-tests-ubuntu:
+  name: 🇨 Test 🐧
+  strategy:
+    fail-fast: false
+    matrix:
+      include:
+        - runs-on: ubuntu-24.04
+          compiler: gcc
+          preset: debug
+          run-on-draft: false
+        - runs-on: ubuntu-24.04-arm
+          compiler: gcc
+          preset: release
+          run-on-draft: false
+  uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@v2.3.0
+  with:
+    runs-on: ${{ matrix.runs-on }}
+    compiler: ${{ matrix.compiler }}
+    preset-name: ${{ matrix.preset }}
+    run-on-draft: ${{ matrix.run-on-draft }}
+```
+
 ## [2.2.2]
 
 This release updates [pypa/cibuildwheel] to `v4.2.0`. As a result, CPython 3.15
@@ -638,7 +704,8 @@ invocations under Windows.
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.2...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.3.0...HEAD
+[2.3.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.3...v2.3.0
 [2.2.2]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.1...v2.2.2
 [2.2.1]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.1.0...v2.2.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -82,8 +82,7 @@ sessions whenever the draft status changes, add `ready_for_review` and
 ```yaml
 on:
   pull_request:
-    types:
-      [opened, reopened, synchronize, converted_to_draft, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review]
 ```
 
 ## [2.2.2]

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -72,6 +72,20 @@ cpp-tests-ubuntu:
     run-on-draft: ${{ matrix.run-on-draft }}
 ```
 
+By default, GitHub does not run `pull_request` workflows when a pull request is
+marked ready for review or converted back to a draft. To run the appropriate
+sessions whenever the draft status changes, add `ready_for_review` and
+`converted_to_draft` to the pull request activity types in `ci.yml`. Specifying
+`types` replaces the defaults, so retain `opened`, `reopened`, and
+`synchronize`:
+
+```yaml
+on:
+  pull_request:
+    types:
+      [opened, reopened, synchronize, converted_to_draft, ready_for_review]
+```
+
 ## [2.2.2]
 
 This release updates [pypa/cibuildwheel] to `v4.2.0`. As a result, CPython 3.15


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Allow callers to configure the Nox sessions used for draft and ready pull requests, with draft pull requests defaulting to the latest supported Python session. Selected sessions now run in a single Nox invocation.

Add a `run-on-draft` input to the reusable C++ test workflows so callers can skip selected matrix jobs before a runner is allocated. Prepare the `v2.3.0` release documentation with migration examples for both interfaces.

Fixes #443

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
