### PR TITLE
📝 Stop listing `macos-26-intel` as an example

### DIFF
--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -13,7 +13,7 @@ on:
       runs-on:
         description: >
           The macOS runner image to use. Defaults to 'macos-latest'.
-          This can be any valid macOS runner image, such as 'macos-15', 'macos-26', or 'macos-26-intel'.
+          This can be any valid macOS runner image, such as 'macos-15' or 'macos-26'.
         default: "macos-latest"
         type: string
       run-on-draft:


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Remove `macos-26-intel` from the examples for the reusable macOS C++ test workflow's `runs-on` input. The workflow remains generic and accepts any valid runner label; this stops presenting the retired MQT test platform as current guidance.

## AI notice

This PR and its contents were created with the assistance of GPT-5.6 Sol via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] ~~I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.~~
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
