### PR TITLE
🔖 Prepare v2.3.1 with Clang 23 linter support

### DIFF
--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -175,7 +175,7 @@ jobs:
         with:
           style: ""
           tidy-checks: ""
-          # Directly point cpp-linter to the LLVM version installed above.
+          # Directly use the installed LLVM version.
           version: ${{ format('/usr/lib/llvm-{0}/bin', inputs.clang-version) }}
           ignore: ${{ format(
             'build|!build/mlir/**|**/include|include{0}{1}',

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -175,8 +175,8 @@ jobs:
         with:
           style: ""
           tidy-checks: ""
-          # cpp-linter-action v2.21.0 accepts versions after 22 only as installed tool paths.
-          version: ${{ inputs.clang-version > 22 && format('/usr/lib/llvm-{0}/bin', inputs.clang-version) || inputs.clang-version }}
+          # Directly point cpp-linter to the LLVM version installed above.
+          version: ${{ format('/usr/lib/llvm-{0}/bin', inputs.clang-version) }}
           ignore: ${{ format(
             'build|!build/mlir/**|**/include|include{0}{1}',
             inputs.cpp-linter-ignore-extra != '' && '|' || '',

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -175,7 +175,8 @@ jobs:
         with:
           style: ""
           tidy-checks: ""
-          version: ${{ inputs.clang-version }}
+          # cpp-linter-action v2.21.0 accepts versions after 22 only as installed tool paths.
+          version: ${{ inputs.clang-version > 22 && format('/usr/lib/llvm-{0}/bin', inputs.clang-version) || inputs.clang-version }}
           ignore: ${{ format(
             'build|!build/mlir/**|**/include|include{0}{1}',
             inputs.cpp-linter-ignore-extra != '' && '|' || '',

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [2.3.1] - 2026-09-05
+
 ### Changed
 
 - ♻️ Directly pass the LLVM installation directory to `cpp-linter` ([#448])
@@ -482,7 +484,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.3.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.3.1...HEAD
+[2.3.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.1
 [2.3.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.0
 [2.2.3]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.3
 [2.2.2]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Allow `reusable-cpp-linter.yml` callers to select Clang 23 ([#448])
+  ([**@simon1hofmann**])
+
 ## [2.3.0] - 2026-08-24
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#230)._
@@ -522,6 +527,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#448]: https://github.com/munich-quantum-toolkit/workflows/pull/448
 [#442]: https://github.com/munich-quantum-toolkit/workflows/pull/442
 [#441]: https://github.com/munich-quantum-toolkit/workflows/pull/441
 [#434]: https://github.com/munich-quantum-toolkit/workflows/pull/434
@@ -593,6 +599,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 [**@ystade**]: https://github.com/ystade
 [**@denialhaag**]: https://github.com/denialhaag
 [**@flowerthrower**]: https://github.com/flowerthrower
+[**@simon1hofmann**]: https://github.com/simon1hofmann
 
 <!-- General links -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
-### Fixed
+### Changed
 
-- 🐛 Allow `reusable-cpp-linter.yml` callers to select Clang 23 ([#448])
+- ♻️ Directly pass the LLVM installation directory to `cpp-linter` ([#448])
   ([**@simon1hofmann**])
 
 ## [2.3.0] - 2026-08-24


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

This PR prepares the patch release `v2.3.1`.

It directly passes the LLVM installation directory prepared by `reusable-cpp-linter.yml` to `cpp-linter`. The workflow already installs the requested Clang, clang-format, clang-tidy, and clang-tools packages before invoking `cpp-linter-action`. Pointing the action at `/usr/lib/llvm-<version>/bin` makes that installed toolchain authoritative and allows callers to select Clang 23 without version-specific workflow logic or changes to the existing input and default.

This also bypasses the numeric-version limit in `cpp-linter-action` v2.21.0's bundled `clang-tools` 1.2.0 resolver. That limit caused the [jeff-mlir failure](https://github.com/unitaryfoundation/jeff-mlir/actions/runs/33410902201) after LLVM 23 itself had installed successfully.

AI assistance: GPT-5.6 Sol via Codex helped inspect the shared consumers, implement and validate the change, and prepare the release.

## Validation

- `uvx prek run -a`
- `git diff --check`
- Ubuntu 24.04 amd64 container: `llvm.sh 23` installed Clang 23.1.1, clang-format 23.1.1, and clang-tidy 23.1.1 under `/usr/lib/llvm-23/bin`
- MQT Core full-tree canary: [munich-quantum-toolkit/core#2328](https://github.com/munich-quantum-toolkit/core/pull/2328) (passed)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
