### PR TITLE
⚡ Enable shared sccache across CI

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -39,6 +39,7 @@ jobs:
     name: 📈 Coverage
     runs-on: ubuntu-24.04
     permissions:
+      actions: write # Required to replace the preceding ccache entry on main
       contents: read # Required for the `actions/checkout` action
       id-token: write # Required for the `codecov/codecov-action` action
     env:
@@ -73,8 +74,11 @@ jobs:
       - name: Set up ccache
         uses: Chocobo1/setup-ccache-action@a4d08616f5b614053bce228ddf881592f69d61d4 # v1.5.9
         with:
+          ccache_options: max_size=500M
           prepend_symlinks_to_path: false
           override_cache_key: c++-coverage
+          remove_stale_cache: ${{ github.ref == 'refs/heads/main' }}
+          store_cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up mold as linker
         uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -50,7 +50,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -26,6 +26,10 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-sccache-gha:
+        description: "Whether to use sccache with the GitHub Actions cache backend"
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-coverage
@@ -39,13 +43,14 @@ jobs:
     name: 📈 Coverage
     runs-on: ubuntu-24.04
     permissions:
-      actions: write # Required to replace the preceding ccache entry on main
       contents: read # Required for the `actions/checkout` action
       id-token: write # Required for the `codecov/codecov-action` action
     env:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -70,15 +75,9 @@ jobs:
         with:
           llvm-version: ${{ inputs.llvm-version }}
 
-      # set up ccache for faster builds
-      - name: Set up ccache
-        uses: Chocobo1/setup-ccache-action@a4d08616f5b614053bce228ddf881592f69d61d4 # v1.5.9
-        with:
-          ccache_options: max_size=500M
-          prepend_symlinks_to_path: false
-          override_cache_key: c++-coverage
-          remove_stale_cache: ${{ github.ref == 'refs/heads/main' }}
-          store_cache: ${{ github.ref == 'refs/heads/main' }}
+      - name: Set up sccache
+        if: ${{ inputs.use-sccache-gha }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Set up mold as linker
         uses: rui314/setup-mold@7e4f20ad28a2e8ca6fd0892ccf72e2abb706b9c3 # v1
@@ -107,6 +106,12 @@ jobs:
 
       - name: Test
         run: ctest --preset coverage
+
+      - name: Verify sccache use
+        if: ${{ inputs.use-sccache-gha }}
+        run: |
+          sccache --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -67,6 +67,7 @@ jobs:
     name: 🚨 Lint
     runs-on: ubuntu-24.04
     permissions:
+      actions: write # Required to replace the preceding ccache entry on main
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments
     env:
@@ -100,8 +101,11 @@ jobs:
         if: ${{ inputs.build-project }}
         uses: Chocobo1/setup-ccache-action@a4d08616f5b614053bce228ddf881592f69d61d4 # v1.5.9
         with:
+          ccache_options: max_size=500M
           prepend_symlinks_to_path: false
           override_cache_key: c++-lint
+          remove_stale_cache: ${{ github.ref == 'refs/heads/main' }}
+          store_cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up mold as linker
         if: ${{ inputs.build-project }}

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -26,6 +26,10 @@ on:
         description: "Whether to build the project"
         default: false
         type: boolean
+      use-sccache-gha:
+        description: "Whether project builds use sccache with the GitHub Actions cache backend"
+        default: true
+        type: boolean
       setup-z3:
         description: "Whether to set up Z3"
         default: false
@@ -67,11 +71,12 @@ jobs:
     name: 🚨 Lint
     runs-on: ubuntu-24.04
     permissions:
-      actions: write # Required to replace the preceding ccache entry on main
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments
     env:
       CLANG_VERSION: ${{ inputs.clang-version }}
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -96,16 +101,9 @@ jobs:
         with:
           llvm-version: ${{ inputs.llvm-version }}
 
-      # set up ccache for faster builds
-      - name: Set up ccache
-        if: ${{ inputs.build-project }}
-        uses: Chocobo1/setup-ccache-action@a4d08616f5b614053bce228ddf881592f69d61d4 # v1.5.9
-        with:
-          ccache_options: max_size=500M
-          prepend_symlinks_to_path: false
-          override_cache_key: c++-lint
-          remove_stale_cache: ${{ github.ref == 'refs/heads/main' }}
-          store_cache: ${{ github.ref == 'refs/heads/main' }}
+      - name: Set up sccache
+        if: ${{ inputs.build-project && inputs.use-sccache-gha }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Set up mold as linker
         if: ${{ inputs.build-project }}
@@ -169,6 +167,12 @@ jobs:
       - name: Build
         if: ${{ inputs.build-project }}
         run: cmake --build build
+
+      - name: Verify sccache use
+        if: ${{ inputs.build-project && inputs.use-sccache-gha }}
+        run: |
+          sccache --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'
 
       # runs the cpp-linter action using the generated compilation database and the specified clang version
       - name: Run cpp-linter

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -76,7 +76,7 @@ jobs:
     env:
       CLANG_VERSION: ${{ inputs.clang-version }}
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -49,6 +49,10 @@ on:
         description: "The CMake preset to use for configuration and build"
         required: true
         type: string
+      use-sccache-gha:
+        description: "Whether to use sccache with the GitHub Actions cache backend"
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
@@ -66,6 +70,8 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -99,6 +105,10 @@ jobs:
 
       - name: Install Ninja
         run: uv tool install ninja
+
+      - name: Set up sccache
+        if: ${{ inputs.use-sccache-gha }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
@@ -146,7 +156,13 @@ jobs:
       - name: Configure CMake
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --preset "$PRESET_NAME"
+          USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
+        run: |
+          args=()
+          if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
+            args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
+          fi
+          cmake --preset "$PRESET_NAME" "${args[@]}"
 
       - name: Build
         env:
@@ -157,3 +173,9 @@ jobs:
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"
+
+      - name: Verify sccache use
+        if: ${{ inputs.use-sccache-gha }}
+        run: |
+          sccache --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -71,7 +71,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -49,6 +49,10 @@ on:
         description: "The CMake preset to use for configuration and build"
         required: true
         type: string
+      use-sccache-gha:
+        description: "Whether to use sccache with the GitHub Actions cache backend"
+        default: true
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
@@ -66,6 +70,8 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -102,6 +108,10 @@ jobs:
 
       - name: Install Ninja
         run: uv tool install ninja
+
+      - name: Set up sccache
+        if: ${{ inputs.use-sccache-gha }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
@@ -146,7 +156,13 @@ jobs:
       - name: Configure CMake
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --preset "$PRESET_NAME"
+          USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
+        run: |
+          args=()
+          if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
+            args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
+          fi
+          cmake --preset "$PRESET_NAME" "${args[@]}"
 
       - name: Build
         env:
@@ -157,3 +173,9 @@ jobs:
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"
+
+      - name: Verify sccache use
+        if: ${{ inputs.use-sccache-gha }}
+        run: |
+          sccache --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -71,7 +71,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -51,10 +51,6 @@ on:
         description: "The CMake preset to use for configuration and build"
         required: true
         type: string
-      use-ninja:
-        description: "Whether to use Ninja instead of the preset's default generator"
-        default: false
-        type: boolean
       use-lld:
         description: "Whether to enable LLD"
         default: false
@@ -84,6 +80,9 @@ jobs:
       CMAKE_BUILD_PARALLEL_LEVEL: 4
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-{2}-llvm-{3}', github.workflow, inputs.runs-on, inputs.compiler, inputs.llvm-version) || '' }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -186,27 +185,13 @@ jobs:
           enable-cache: false
 
       - name: Install Ninja
-        if: ${{ inputs.use-ninja }}
         run: uv tool install ninja==1.13.0
 
-      - name: Install sccache
+      - name: Set up sccache
         if: ${{ inputs.use-sccache-gha }}
-        run: uv tool install sccache
-
-      - name: Configure sccache GitHub Actions cache
-        if: ${{ inputs.use-sccache-gha }}
-        continue-on-error: true
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          SCCACHE_GHA_VERSION: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ inputs.llvm-version }}
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-            core.exportVariable('SCCACHE_GHA_ENABLED', 'on');
-            core.exportVariable('SCCACHE_GHA_VERSION', process.env.SCCACHE_GHA_VERSION);
-            core.exportVariable('SCCACHE_GHA_RW_MODE', process.env.SCCACHE_GHA_RW_MODE);
+          version: v0.17.0
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
@@ -218,13 +203,9 @@ jobs:
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
           USE_LLD: ${{ inputs.use-lld }}
-          USE_NINJA: ${{ inputs.use-ninja }}
           USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
         run: |
           args=()
-          if [[ "$USE_NINJA" == "true" ]]; then
-            args+=(-G Ninja)
-          fi
           if [[ "$USE_LLD" == "true" ]]; then
             args+=(-DLLVM_ENABLE_LLD=ON)
           fi
@@ -244,7 +225,8 @@ jobs:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"
 
-      - name: Show sccache stats
+      - name: Verify sccache use
         if: ${{ inputs.use-sccache-gha }}
-        continue-on-error: true
-        run: sccache --show-stats
+        run: |
+          "$SCCACHE_PATH" --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -51,6 +51,18 @@ on:
         description: "The CMake preset to use for configuration and build"
         required: true
         type: string
+      use-ninja:
+        description: "Whether to use Ninja instead of the preset's default generator"
+        default: false
+        type: boolean
+      use-lld:
+        description: "Whether to enable LLD"
+        default: false
+        type: boolean
+      use-sccache-gha:
+        description: "Whether to use sccache with the GitHub Actions cache backend"
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-cpp-tests-${{ inputs.runs-on }}-${{ inputs.compiler }}-${{ inputs.preset-name }}
@@ -84,6 +96,75 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Set up MSVC
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $vsArch = switch ($env:RUNNER_ARCH) {
+            'X64' { 'amd64' }
+            'ARM64' { 'arm64' }
+            default { throw "Unsupported Windows runner architecture: $env:RUNNER_ARCH" }
+          }
+          $component = switch ($env:RUNNER_ARCH) {
+            'X64' { 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64' }
+            'ARM64' { 'Microsoft.VisualStudio.Component.VC.Tools.ARM64' }
+          }
+
+          $candidates = @(
+            if (${env:ProgramFiles(x86)}) {
+              Join-Path ${env:ProgramFiles(x86)} 'Microsoft Visual Studio\Installer\vswhere.exe'
+            }
+            if ($env:ProgramFiles) {
+              Join-Path $env:ProgramFiles 'Microsoft Visual Studio\Installer\vswhere.exe'
+            }
+            Get-Command vswhere.exe -ErrorAction SilentlyContinue | Select-Object -ExpandProperty Source
+          )
+          $vswhere = $candidates | Where-Object { $_ -and (Test-Path $_) } | Select-Object -First 1
+          if (-not $vswhere) {
+            throw 'vswhere.exe not found'
+          }
+
+          $vsPath = (& $vswhere -latest -products '*' -prerelease -requires $component -property installationPath | Select-Object -First 1)
+          if (-not $vsPath) {
+            throw "Visual Studio with $component not found"
+          }
+          $devShell = Join-Path $vsPath 'Common7\Tools\Launch-VsDevShell.ps1'
+          if (-not (Test-Path $devShell)) {
+            throw "Developer shell not found: $devShell"
+          }
+
+          $before = @{}
+          Get-ChildItem Env: | ForEach-Object { $before[$_.Name] = $_.Value }
+          $devShellArguments = @{
+            Arch = $vsArch
+            SkipAutomaticLocation = $true
+          }
+          if ($env:RUNNER_ARCH -eq 'X64') {
+            $devShellArguments.HostArch = 'amd64'
+          }
+          & $devShell @devShellArguments
+
+          $compiler = (Get-Command cl.exe -ErrorAction Stop).Source
+          $expected = if ($env:RUNNER_ARCH -eq 'ARM64') { '\Hostarm64\arm64\' } else { '\Hostx64\x64\' }
+          if ($compiler -notmatch [regex]::Escape($expected)) {
+            throw "Unexpected MSVC compiler for $($env:RUNNER_ARCH): $compiler"
+          }
+          Write-Host "Using $compiler"
+
+          Get-ChildItem Env: | ForEach-Object {
+            if (
+              (!$before.ContainsKey($_.Name) -or $before[$_.Name] -cne $_.Value) -and
+              $_.Name -notmatch '^(GITHUB_|RUNNER_)' -and
+              $_.Name -ne 'NODE_OPTIONS'
+            ) {
+              $delimiter = "ghadelimiter_$([guid]::NewGuid().ToString('N'))"
+              Add-Content -Path $env:GITHUB_ENV -Value "$($_.Name)<<$delimiter" -Encoding utf8
+              Add-Content -Path $env:GITHUB_ENV -Value $_.Value -Encoding utf8
+              Add-Content -Path $env:GITHUB_ENV -Value $delimiter -Encoding utf8
+            }
+          }
+
       - name: Set up Z3
         if: ${{ inputs.setup-z3 }}
         uses: cda-tum/setup-z3@0401375ea1e34d77ef35bbeb634f6203f3bcde60 # v1.7.3
@@ -104,6 +185,29 @@ jobs:
           activate-environment: true
           enable-cache: false
 
+      - name: Install Ninja
+        if: ${{ inputs.use-ninja }}
+        run: uv tool install ninja==1.13.0
+
+      - name: Install sccache
+        if: ${{ inputs.use-sccache-gha }}
+        run: uv tool install sccache
+
+      - name: Configure sccache GitHub Actions cache
+        if: ${{ inputs.use-sccache-gha }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SCCACHE_GHA_VERSION: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ inputs.llvm-version }}
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'on');
+            core.exportVariable('SCCACHE_GHA_VERSION', process.env.SCCACHE_GHA_VERSION);
+            core.exportVariable('SCCACHE_GHA_RW_MODE', process.env.SCCACHE_GHA_RW_MODE);
+
       - name: Install lit
         if: ${{ inputs.setup-mlir }}
         run: |
@@ -113,7 +217,21 @@ jobs:
       - name: Configure CMake
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-        run: cmake --preset "$PRESET_NAME"
+          USE_LLD: ${{ inputs.use-lld }}
+          USE_NINJA: ${{ inputs.use-ninja }}
+          USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
+        run: |
+          args=()
+          if [[ "$USE_NINJA" == "true" ]]; then
+            args+=(-G Ninja)
+          fi
+          if [[ "$USE_LLD" == "true" ]]; then
+            args+=(-DLLVM_ENABLE_LLD=ON)
+          fi
+          if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
+            args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
+          fi
+          cmake --preset "$PRESET_NAME" "${args[@]}"
 
       - name: Build
         timeout-minutes: 60
@@ -125,3 +243,8 @@ jobs:
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
         run: ctest --preset "$PRESET_NAME"
+
+      - name: Show sccache stats
+        if: ${{ inputs.use-sccache-gha }}
+        continue-on-error: true
+        run: sccache --show-stats

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -228,5 +228,5 @@ jobs:
       - name: Verify sccache use
         if: ${{ inputs.use-sccache-gha }}
         run: |
-          "$SCCACHE_PATH" --show-stats --stats-format json |
+          sccache --show-stats --stats-format json |
             python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -57,7 +57,7 @@ on:
         type: boolean
       use-sccache-gha:
         description: "Whether to use sccache with the GitHub Actions cache backend"
-        default: false
+        default: true
         type: boolean
 
 concurrency:
@@ -81,7 +81,6 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-{2}-llvm-{3}', github.workflow, inputs.runs-on, inputs.compiler, inputs.llvm-version) || '' }}
       SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
@@ -185,13 +184,11 @@ jobs:
           enable-cache: false
 
       - name: Install Ninja
-        run: uv tool install ninja==1.13.0
+        run: uv tool install ninja
 
       - name: Set up sccache
         if: ${{ inputs.use-sccache-gha }}
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.17.0
 
       - name: Install lit
         if: ${{ inputs.setup-mlir }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -51,10 +51,6 @@ on:
         description: "The CMake preset to use for configuration and build"
         required: true
         type: string
-      use-lld:
-        description: "Whether to enable LLD"
-        default: false
-        type: boolean
       use-sccache-gha:
         description: "Whether to use sccache with the GitHub Actions cache backend"
         default: true
@@ -81,7 +77,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -199,13 +195,9 @@ jobs:
       - name: Configure CMake
         env:
           PRESET_NAME: ${{ inputs.preset-name }}
-          USE_LLD: ${{ inputs.use-lld }}
           USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
         run: |
           args=()
-          if [[ "$USE_LLD" == "true" ]]; then
-            args+=(-DLLVM_ENABLE_LLD=ON)
-          fi
           if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
             args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
           fi

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -31,6 +31,10 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      use-sccache-gha:
+        description: "Whether non-Ubuntu builds use the GitHub Actions cache backend for sccache"
+        default: false
+        type: boolean
     secrets:
       AWS_S3_BUCKET:
         description: "S3 bucket used by AWS-backed wheel tests"
@@ -54,6 +58,9 @@ jobs:
     name: 🎡 ${{ inputs.runs-on }}
     runs-on: ${{ inputs.runs-on }}
     env:
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-llvm-{2}', github.workflow, inputs.runs-on, inputs.llvm-version) || '' }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -84,10 +91,11 @@ jobs:
           enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      # set up sccache for faster builds (non-Ubuntu only)
-      - name: Install sccache
+      - name: Set up sccache
         if: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
-        run: uv tool install sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        with:
+          version: v0.17.0
 
       # run cibuildwheel to build wheels for the specified Python version
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
@@ -103,6 +111,8 @@ jobs:
           name: ${{ github.event_name == 'pull_request' && 'dev-' || '' }}cibw-wheels-${{ inputs.runs-on }}
           path: wheelhouse/*.whl
 
-      - name: Show sccache stats
-        if: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
-        run: sccache --show-stats
+      - name: Verify sccache use
+        if: ${{ inputs.use-sccache-gha && !startsWith(inputs.runs-on, 'ubuntu') }}
+        run: |
+          "$SCCACHE_PATH" --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') && !inputs.use-sccache-gha }}
+          enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up sccache

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -114,5 +114,5 @@ jobs:
       - name: Verify sccache use
         if: ${{ inputs.use-sccache-gha && !startsWith(inputs.runs-on, 'ubuntu') }}
         run: |
-          "$SCCACHE_PATH" --show-stats --stats-format json |
+          sccache --show-stats --stats-format json |
             python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
+          enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') && !inputs.use-sccache-gha }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up sccache

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -31,10 +31,6 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
-      use-sccache-gha:
-        description: "Whether non-Ubuntu builds use the GitHub Actions cache backend for sccache"
-        default: true
-        type: boolean
     secrets:
       AWS_S3_BUCKET:
         description: "S3 bucket used by AWS-backed wheel tests"
@@ -58,8 +54,6 @@ jobs:
     name: 🎡 ${{ inputs.runs-on }}
     runs-on: ${{ inputs.runs-on }}
     env:
-      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -90,19 +84,10 @@ jobs:
           enable-cache: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      - name: Set up sccache
+      # set up sccache for faster builds (non-Ubuntu only)
+      - name: Install sccache
         if: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-
-      - name: Configure Windows native builds
-        if: runner.os == 'Windows'
-        shell: bash
-        run: |
-          {
-            echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
-            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
-          } >> "$GITHUB_ENV"
+        run: uv tool install sccache
 
       # run cibuildwheel to build wheels for the specified Python version
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0
@@ -118,8 +103,6 @@ jobs:
           name: ${{ github.event_name == 'pull_request' && 'dev-' || '' }}cibw-wheels-${{ inputs.runs-on }}
           path: wheelhouse/*.whl
 
-      - name: Verify sccache use
-        if: ${{ inputs.use-sccache-gha && !startsWith(inputs.runs-on, 'ubuntu') }}
-        run: |
-          sccache --show-stats --stats-format json |
-            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'
+      - name: Show sccache stats
+        if: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
+        run: sccache --show-stats

--- a/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
+++ b/.github/workflows/reusable-python-packaging-wheel-cibuildwheel.yml
@@ -33,7 +33,7 @@ on:
         type: string
       use-sccache-gha:
         description: "Whether non-Ubuntu builds use the GitHub Actions cache backend for sccache"
-        default: false
+        default: true
         type: boolean
     secrets:
       AWS_S3_BUCKET:
@@ -59,7 +59,6 @@ jobs:
     runs-on: ${{ inputs.runs-on }}
     env:
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
-      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-llvm-{2}', github.workflow, inputs.runs-on, inputs.llvm-version) || '' }}
       SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
@@ -94,8 +93,16 @@ jobs:
       - name: Set up sccache
         if: ${{ !startsWith(inputs.runs-on, 'ubuntu') }}
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.17.0
+
+      - name: Configure Windows native builds
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          {
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          } >> "$GITHUB_ENV"
 
       # run cibuildwheel to build wheels for the specified Python version
       - uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074 # v4.2.0

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -40,7 +40,7 @@ on:
         type: string
       free-disk-space:
         description: "Whether to free disk space before running the tests"
-        default: true
+        default: false
         type: boolean
       use-lld:
         description: "Whether to use LLD for Windows native builds"
@@ -65,6 +65,9 @@ jobs:
     env:
       FORCE_COLOR: 3
       GITHUB_TOKEN: ${{ github.token }}
+      SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-llvm-{2}', github.workflow, inputs.runs-on, inputs.llvm-version) || '' }}
+      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -204,24 +207,10 @@ jobs:
         with:
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
-      # set up sccache for faster builds
-      - name: Install sccache
-        run: uv tool install sccache
-
-      - name: Configure sccache GitHub Actions cache
-        if: ${{ inputs.use-sccache-gha }}
-        continue-on-error: true
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          SCCACHE_GHA_VERSION: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ inputs.llvm-version }}
-          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+      - name: Set up sccache
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-            core.exportVariable('SCCACHE_GHA_ENABLED', 'on');
-            core.exportVariable('SCCACHE_GHA_VERSION', process.env.SCCACHE_GHA_VERSION);
-            core.exportVariable('SCCACHE_GHA_RW_MODE', process.env.SCCACHE_GHA_RW_MODE);
+          version: v0.17.0
 
       - if: ${{ !github.event.pull_request.draft }}
         name: 🐍 Test
@@ -249,6 +238,8 @@ jobs:
           path: coverage-*
           archive: false
 
-      - name: Show sccache stats
-        continue-on-error: true
-        run: sccache --show-stats
+      - name: Verify sccache use
+        if: ${{ inputs.use-sccache-gha }}
+        run: |
+          "$SCCACHE_PATH" --show-stats --stats-format json |
+            python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -38,6 +38,18 @@ on:
         description: "The LLVM version to set up (formatted as 'major.minor.patch') or commit hash (minimum 7 characters, e.g., 'a832a52')"
         default: "21.1.8"
         type: string
+      free-disk-space:
+        description: "Whether to free disk space before running the tests"
+        default: true
+        type: boolean
+      use-lld:
+        description: "Whether to use LLD for Windows native builds"
+        default: false
+        type: boolean
+      use-sccache-gha:
+        description: "Whether to use the GitHub Actions cache backend for sccache"
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}-python-tests-${{ inputs.runs-on }}
@@ -62,20 +74,20 @@ jobs:
       # free up space on the runners
       # the nox environments can get quite large, especially if torch is installed
       - name: Free up space (Linux)
-        if: runner.os == 'Linux'
+        if: inputs.free-disk-space && runner.os == 'Linux'
         run: |
           sudo rm -rf /opt/ghc || true
           sudo rm -rf /usr/local/lib/android/sdk || true
           sudo rm -rf /usr/share/dotnet || true
           sudo rm -rf /usr/share/swift || true
       - name: Free up space (macOS)
-        if: runner.os == 'macOS'
+        if: inputs.free-disk-space && runner.os == 'macOS'
         run: |
           sudo rm -rf /usr/local/share/android-sdk || true
           sudo rm -rf /usr/local/share/dotnet || true
           sudo rm -rf /usr/share/swift || true
       - name: Free up space (Windows)
-        if: runner.os == 'Windows'
+        if: inputs.free-disk-space && runner.os == 'Windows'
         run: |
           Remove-Item -Recurse -Force "C:\Android\android-sdk" -ErrorAction SilentlyContinue
           Remove-Item -Recurse -Force "C:\Program Files\dotnet" -ErrorAction SilentlyContinue
@@ -160,10 +172,17 @@ jobs:
       - name: Configure Windows native builds
         if: runner.os == 'Windows'
         shell: bash
+        env:
+          USE_LLD: ${{ inputs.use-lld }}
         run: |
-          echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
-          echo "CMAKE_C_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
-          echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache" >> "$GITHUB_ENV"
+          {
+            echo "CMAKE_GENERATOR=Ninja"
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
+            if [[ "$USE_LLD" == "true" ]]; then
+              echo "SKBUILD_CMAKE_ARGS=-DLLVM_ENABLE_LLD=ON"
+            fi
+          } >> "$GITHUB_ENV"
 
       - name: Set up Z3
         if: ${{ inputs.setup-z3 }}
@@ -188,6 +207,21 @@ jobs:
       # set up sccache for faster builds
       - name: Install sccache
         run: uv tool install sccache
+
+      - name: Configure sccache GitHub Actions cache
+        if: ${{ inputs.use-sccache-gha }}
+        continue-on-error: true
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          SCCACHE_GHA_VERSION: ${{ runner.os }}-${{ runner.arch }}-llvm-${{ inputs.llvm-version }}
+          SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+            core.exportVariable('SCCACHE_GHA_ENABLED', 'on');
+            core.exportVariable('SCCACHE_GHA_VERSION', process.env.SCCACHE_GHA_VERSION);
+            core.exportVariable('SCCACHE_GHA_RW_MODE', process.env.SCCACHE_GHA_RW_MODE);
 
       - if: ${{ !github.event.pull_request.draft }}
         name: 🐍 Test
@@ -216,4 +250,5 @@ jobs:
           archive: false
 
       - name: Show sccache stats
+        continue-on-error: true
         run: sccache --show-stats

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -205,6 +205,7 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
+          enable-cache: ${{ !inputs.use-sccache-gha }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up sccache

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -42,10 +42,6 @@ on:
         description: "Whether to free disk space before running the tests"
         default: false
         type: boolean
-      use-lld:
-        description: "Whether to use LLD for Windows native builds"
-        default: false
-        type: boolean
       use-sccache-gha:
         description: "Whether to use the GitHub Actions cache backend for sccache"
         default: true
@@ -69,7 +65,7 @@ jobs:
       CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
       SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
+      SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
       AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
@@ -177,15 +173,7 @@ jobs:
       - name: Configure Windows native builds
         if: runner.os == 'Windows'
         shell: bash
-        env:
-          USE_LLD: ${{ inputs.use-lld }}
-        run: |
-          {
-            echo "CMAKE_GENERATOR=Ninja"
-            if [[ "$USE_LLD" == "true" ]]; then
-              echo "SKBUILD_CMAKE_ARGS=-DLLVM_ENABLE_LLD=ON"
-            fi
-          } >> "$GITHUB_ENV"
+        run: echo "CMAKE_GENERATOR=Ninja" >> "$GITHUB_ENV"
 
       - name: Set up Z3
         if: ${{ inputs.setup-z3 }}

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -241,5 +241,5 @@ jobs:
       - name: Verify sccache use
         if: ${{ inputs.use-sccache-gha }}
         run: |
-          "$SCCACHE_PATH" --show-stats --stats-format json |
+          sccache --show-stats --stats-format json |
             python -c 'import json, sys; assert json.load(sys.stdin)["stats"]["compile_requests"] > 0'

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -178,13 +178,13 @@ jobs:
         env:
           USE_LLD: ${{ inputs.use-lld }}
         run: |
+          skbuild_cmake_args="-DCMAKE_C_COMPILER_LAUNCHER=sccache;-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
+          if [[ "$USE_LLD" == "true" ]]; then
+            skbuild_cmake_args+=";-DLLVM_ENABLE_LLD=ON"
+          fi
           {
             echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
-            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
-            if [[ "$USE_LLD" == "true" ]]; then
-              echo "SKBUILD_CMAKE_ARGS=-DLLVM_ENABLE_LLD=ON"
-            fi
+            echo "SKBUILD_CMAKE_ARGS=$skbuild_cmake_args"
           } >> "$GITHUB_ENV"
 
       - name: Set up Z3

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -66,6 +66,7 @@ jobs:
       FORCE_COLOR: 3
       GITHUB_TOKEN: ${{ github.token }}
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-llvm-{2}', github.workflow, inputs.runs-on, inputs.llvm-version) || '' }}
       SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
@@ -178,13 +179,13 @@ jobs:
         env:
           USE_LLD: ${{ inputs.use-lld }}
         run: |
-          skbuild_cmake_args="-DCMAKE_C_COMPILER_LAUNCHER=sccache;-DCMAKE_CXX_COMPILER_LAUNCHER=sccache"
-          if [[ "$USE_LLD" == "true" ]]; then
-            skbuild_cmake_args+=";-DLLVM_ENABLE_LLD=ON"
-          fi
           {
             echo "CMAKE_GENERATOR=Ninja"
-            echo "SKBUILD_CMAKE_ARGS=$skbuild_cmake_args"
+            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
+            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
+            if [[ "$USE_LLD" == "true" ]]; then
+              echo "SKBUILD_CMAKE_ARGS=-DLLVM_ENABLE_LLD=ON"
+            fi
           } >> "$GITHUB_ENV"
 
       - name: Set up Z3
@@ -205,7 +206,6 @@ jobs:
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          enable-cache: ${{ !inputs.use-sccache-gha }}
           save-cache: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Set up sccache

--- a/.github/workflows/reusable-python-tests.yml
+++ b/.github/workflows/reusable-python-tests.yml
@@ -48,7 +48,7 @@ on:
         type: boolean
       use-sccache-gha:
         description: "Whether to use the GitHub Actions cache backend for sccache"
-        default: false
+        default: true
         type: boolean
 
 concurrency:
@@ -65,9 +65,10 @@ jobs:
     env:
       FORCE_COLOR: 3
       GITHUB_TOKEN: ${{ github.token }}
+      CMAKE_C_COMPILER_LAUNCHER: sccache
+      CMAKE_CXX_COMPILER_LAUNCHER: sccache
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
       SCCACHE_IDLE_TIMEOUT: 0
-      SCCACHE_GHA_VERSION: ${{ inputs.use-sccache-gha && format('{0}-{1}-llvm-{2}', github.workflow, inputs.runs-on, inputs.llvm-version) || '' }}
       SCCACHE_GHA_RW_MODE: ${{ (github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch') && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}
@@ -181,8 +182,6 @@ jobs:
         run: |
           {
             echo "CMAKE_GENERATOR=Ninja"
-            echo "CMAKE_C_COMPILER_LAUNCHER=sccache"
-            echo "CMAKE_CXX_COMPILER_LAUNCHER=sccache"
             if [[ "$USE_LLD" == "true" ]]; then
               echo "SKBUILD_CMAKE_ARGS=-DLLVM_ENABLE_LLD=ON"
             fi
@@ -210,8 +209,6 @@ jobs:
 
       - name: Set up sccache
         uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
-        with:
-          version: v0.17.0
 
       - if: ${{ !github.event.pull_request.draft }}
         name: 🐍 Test


### PR DESCRIPTION
🤖 *AI text below* 🤖

## Description

Enable GitHub-backed sccache by default across the reusable C++ test workflows on Linux, macOS, and Windows, the C++ linter and coverage workflows, and ordinary Python tests. The cibuildwheel and CD workflows are unchanged.

- use the official sccache action and let it select the current sccache release;
- install the current Ninja release with `uv tool install ninja` in direct CMake workflows;
- let scikit-build-core provision Ninja for Python package builds, while forcing Ninja on Windows/MSVC where compiler launchers require it;
- replace the linter and coverage workflows' archive-based ccache setup with the shared sccache backend;
- verify that enabled jobs actually route compiler requests through sccache;
- allow only `main` to write shared cache entries; pull requests and other branches are read-only;
- preserve architecture-aware MSVC initialization and use the consuming project's standard CMake preset on Windows.

The `use-sccache-gha` input remains available as an opt-out and defaults to `true`.

### Experiment results

MQT Core draft PR munich-quantum-toolkit/core#2426 pins this revision and exercises the full platform matrix.

| C++ job | Cold | Final warm | Reduction |
| --- | ---: | ---: | ---: |
| Windows x64 | 17m52s | 3m34s | 80% |
| Windows ARM64 | 13m30s | 4m16s | 68% |
| Ubuntu ARM64 | 8m27s | 1m42s | 80% |
| Linter | 14m02s | 2m21s | 83% |
| Coverage | 10m37s | 4m15s | 60% |

| Python test job | Cold | Final warm | Reduction |
| --- | ---: | ---: | ---: |
| Ubuntu x64 | 18m52s | 12m34s | 34% |
| Ubuntu ARM64 | 14m59s | 11m51s | 21% |
| macOS | 15m21s | 13m02s | 15% |
| Windows x64 | 27m05s | 15m45s | 42% |

The final exact-head run served every C++ compiler request from cache: 159/159 in each full C++ build and coverage job, 350/350 in the linter, and 23/23 in the no-MLIR build. Python tests recorded 135 Ubuntu x64, 134 Ubuntu ARM64, 134 macOS, and 110 Windows hits, with zero misses and zero cache read/write errors on every platform.

The initial concurrent cold run encountered non-fatal GitHub cache write-rate errors. Restricting writes to `main` bounds write contention and cache growth while keeping branch and pull-request builds able to reuse the default-branch cache.

An LLD comparison was also run on Windows. With an effectively complete compiler cache, x64 C++ build steps took 60.2s with LLD versus 62.0–74.3s without it; ARM64 took 62.2s with LLD versus 61.5–64.8s without it. This is normal runner variation, so the unhelpful LLD option was removed.

The obsolete timestamped linter and coverage ccache archives were deleted separately. The verified post-cleanup snapshot contains no `c++-lint_*` or `c++-coverage_*` cache entries; active runs using the old workflow can recreate them until the rollout reaches `main`.

Prepared with GPT-5.6/Codex assistance under explicit maintainer authorization.

### Validation

- `uvx prek run --all-files`
- MQT Core shared-preset configure and build
- MQT Core C++ tests (375 passed)
- MQT Core manual cold full-matrix run [34111068554](https://github.com/munich-quantum-toolkit/core/actions/runs/34111068554) (passed)
- MQT Core exact-head PR run [34122741185](https://github.com/munich-quantum-toolkit/core/actions/runs/34122741185) at `d4f77a06e876637fc5ee134d423ec223bd539cb1` (passed)
- MQT Core final full-matrix run [34122770074](https://github.com/munich-quantum-toolkit/core/actions/runs/34122770074) at `d4f77a06e876637fc5ee134d423ec223bd539cb1` (passed)
- CodeQL, zizmor, CodeRabbit, and pre-commit.ci at this PR head (passed)

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] I have added appropriate tests that cover the new/changed functionality.
- [x] I have updated the documentation to reflect these changes.
- [ ] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [ ] I have added migration instructions to the upgrade guide (if needed).
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [ ] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our AI Usage Guidelines.
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [ ] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
