### PR TITLE
🐛 Preserve sccache statistics through long C++ jobs

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -50,6 +50,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -80,6 +80,7 @@ jobs:
     env:
       CLANG_VERSION: ${{ inputs.clang-version }}
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}

--- a/.github/workflows/reusable-cpp-tests-macos.yml
+++ b/.github/workflows/reusable-cpp-tests-macos.yml
@@ -71,6 +71,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}

--- a/.github/workflows/reusable-cpp-tests-ubuntu.yml
+++ b/.github/workflows/reusable-cpp-tests-ubuntu.yml
@@ -71,6 +71,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}

--- a/.github/workflows/reusable-cpp-tests-windows.yml
+++ b/.github/workflows/reusable-cpp-tests-windows.yml
@@ -77,6 +77,7 @@ jobs:
       CTEST_PARALLEL_LEVEL: 4
       FORCE_COLOR: 3
       SCCACHE_GHA_ENABLED: ${{ inputs.use-sccache-gha }}
+      SCCACHE_IDLE_TIMEOUT: 0
       SCCACHE_GHA_RW_MODE: ${{ github.ref == 'refs/heads/main' && 'READ_WRITE' || 'READ_ONLY' }}
       IQM_TOKEN: ${{ secrets.IQM_TOKEN }}
       IQM_QC_ALIAS: ${{ secrets.IQM_QC_ALIAS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Preserve `sccache` statistics during long C++ test and lint jobs by
+  disabling its idle timeout ([#470]) ([**@denialhaag**])
+
 ## [2.4.0] - 2026-09-11
 
 _If you are upgrading: please see [`UPGRADING.md`](UPGRADING.md#240)._
@@ -565,6 +570,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#470]: https://github.com/munich-quantum-toolkit/workflows/pull/470
 [#463]: https://github.com/munich-quantum-toolkit/workflows/pull/463
 [#462]: https://github.com/munich-quantum-toolkit/workflows/pull/462
 [#461]: https://github.com/munich-quantum-toolkit/workflows/pull/461

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [2.4.1] - 2026-09-11
+
 ### Fixed
 
 - 🐛 Preserve `sccache` statistics during long C++ test and lint jobs by
@@ -523,7 +525,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.4.0...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.4.1...HEAD
+[2.4.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.4.1
 [2.4.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.4.0
 [2.3.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.1
 [2.3.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.0


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Disable the sccache idle timeout in the C++ test, coverage, and linter workflows, matching the Python workflows. This preserves compilation statistics through long test and lint steps.

QMAP's Windows debug tests passed after 668 seconds, but the subsequent cache check reported zero compile requests because sccache had exceeded its default 600-second idle timeout: https://github.com/munich-quantum-toolkit/qmap/actions/runs/34631873358/job/103370504965

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
