### PR TITLE
🐛 Configure sccache for C++ coverage and linter builds

### DIFF
--- a/.github/workflows/reusable-cpp-coverage.yml
+++ b/.github/workflows/reusable-cpp-coverage.yml
@@ -100,7 +100,14 @@ jobs:
           echo "LIT_BIN=$(which lit)" >> $GITHUB_ENV
 
       - name: Configure CMake
-        run: cmake --preset coverage
+        env:
+          USE_SCCACHE_GHA: ${{ inputs.use-sccache-gha }}
+        run: |
+          args=()
+          if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
+            args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
+          fi
+          cmake --preset coverage "${args[@]}"
 
       - name: Build
         run: cmake --build --preset coverage

--- a/.github/workflows/reusable-cpp-linter.yml
+++ b/.github/workflows/reusable-cpp-linter.yml
@@ -167,7 +167,14 @@ jobs:
           fi
 
       - name: Generate compilation database
-        run: cmake -B build --preset lint
+        env:
+          USE_SCCACHE_GHA: ${{ inputs.build-project && inputs.use-sccache-gha }}
+        run: |
+          args=()
+          if [[ "$USE_SCCACHE_GHA" == "true" ]]; then
+            args+=(-DCMAKE_C_COMPILER_LAUNCHER=sccache -DCMAKE_CXX_COMPILER_LAUNCHER=sccache)
+          fi
+          cmake -B build --preset lint "${args[@]}"
 
       - name: Build
         if: ${{ inputs.build-project }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+## [2.4.2] - 2026-09-12
+
 ### Fixed
 
 - 🐛 Configure `sccache` compiler launchers for C++ coverage and linter builds
@@ -530,7 +532,8 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- Version links -->
 
-[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.4.1...HEAD
+[unreleased]: https://github.com/munich-quantum-toolkit/workflows/compare/v2.4.2...HEAD
+[2.4.2]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.4.2
 [2.4.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.4.1
 [2.4.0]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.4.0
 [2.3.1]: https://github.com/munich-quantum-toolkit/workflows/releases/tag/v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ releases may include breaking changes.
 
 ## [Unreleased]
 
+### Fixed
+
+- 🐛 Configure `sccache` compiler launchers for C++ coverage and linter builds
+  ([#472]) ([**@denialhaag**])
+
 ## [2.4.1] - 2026-09-11
 
 ### Fixed
@@ -573,6 +578,7 @@ _📚 Refer to the [GitHub Release Notes] for previous changelogs._
 
 <!-- PR links -->
 
+[#472]: https://github.com/munich-quantum-toolkit/workflows/pull/472
 [#470]: https://github.com/munich-quantum-toolkit/workflows/pull/470
 [#463]: https://github.com/munich-quantum-toolkit/workflows/pull/463
 [#462]: https://github.com/munich-quantum-toolkit/workflows/pull/462


### PR DESCRIPTION
## Description

🤖 *AI text below* 🤖

Configure the C and C++ compiler launchers for coverage and linter builds using the same sccache setup as the C++ test workflows. This enables caching for caller targets and prevents false failures in `Verify sccache use` when dependency builds do not use sccache.

Respect `use-sccache-gha`, and only enable the linter launchers when `build-project` is enabled.

## AI notice

This PR and its contents were created with the assistance of GPT-6 Astra via Codex.

## Checklist

- [x] The pull request only contains commits that are focused and relevant to this change.
- [x] ~~I have added appropriate tests that cover the new/changed functionality.~~
- [x] ~~I have updated the documentation to reflect these changes.~~
- [x] I have added entries to the changelog for any noteworthy additions, changes, fixes, or removals.
- [x] ~~I have added migration instructions to the upgrade guide (if needed).~~
- [x] The changes follow the project's style guidelines and introduce no new warnings.
- [x] The changes are fully tested and pass the CI checks.
- [x] I have reviewed my own code changes.

**If PR contains AI-assisted content:**

- [x] Any agent that created, edited, or submitted GitHub content was explicitly authorized for that scope, as required by our [AI Usage Guidelines](https://github.com/munich-quantum-toolkit/workflows/blob/main/docs/ai_usage.md).
- [x] Every agent-authored or agent-edited public text body begins with the visible disclosure `🤖 *AI text below* 🤖` (titles are exempt).
- [x] I have disclosed AI assistance in the PR description.
- [x] I confirm that I have personally reviewed and understood all AI-generated content, and accept full responsibility for it.
